### PR TITLE
Filter keys in charts to only have values in the time frame

### DIFF
--- a/admin_tools_stats/models.py
+++ b/admin_tools_stats/models.py
@@ -593,10 +593,14 @@ class CriteriaToStatsM2M(models.Model):
                 date_filters = {}
                 current_tz = timezone.get_current_timezone()
                 if time_since is not None:
-                    date_filters[f'{self.stats.date_field_name}__gte'] = current_tz.localize(time_since)
+                    if time_since.tzinfo is None or time_since.tzinfo.utcoffset(time_since) is None:
+                        time_since = current_tz.localize(time_since)
+                    date_filters['%s__gte' % self.stats.date_field_name] = time_since
                 if time_until is not None:
-                    end_time = current_tz.localize(time_until).replace(hour=23, minute=59)
-                    date_filters[f'{self.stats.date_field_name}__lte'] = end_time
+                    if time_until.tzinfo is None or time_until.tzinfo.utcoffset(time_until) is None:
+                        time_until = current_tz.localize(time_until).replace(hour=23, minute=59)
+                    end_time = time_until
+                    date_filters['%s__lte' % self.stats.date_field_name] = end_time
                 choices.update(
                     (
                         (i, (i, fchoices[i] if i in fchoices else i))

--- a/admin_tools_stats/models.py
+++ b/admin_tools_stats/models.py
@@ -567,7 +567,7 @@ class CriteriaToStatsM2M(models.Model):
         return query.resolve_ref(field_name).field
 
     # The slef argument is here just because of this bug: https://github.com/infoscout/django-cache-utils/issues/19
-    @cached(60 * 5)
+    # @cached(60 * 5)
     def _get_dynamic_choices(self, slef, time_since=None, time_until=None):
         model = self.stats.get_model()
         field_name = self.get_dynamic_criteria_field_name()

--- a/admin_tools_stats/models.py
+++ b/admin_tools_stats/models.py
@@ -346,7 +346,7 @@ class DashboardStats(models.Model):
                         single_value = True
 
                     for dynamic_value in dynamic_values:
-                        criteria_value = m2m.get_dynamic_choices()[dynamic_value]
+                        criteria_value = m2m.get_dynamic_choices(time_since, time_until)[dynamic_value]
                         if isinstance(criteria_value, (list, tuple)):
                             criteria_value = criteria_value[0]
                         else:
@@ -414,7 +414,7 @@ class DashboardStats(models.Model):
         all_criteria = self.criteriatostatsm2m_set.all()  # Outside of get_time_series just for performance reasons
         m2m = self.get_multi_series_criteria(configuration)
         if m2m and m2m.criteria.dynamic_criteria_field_name:
-            choices = m2m.get_dynamic_choices()
+            choices = m2m.get_dynamic_choices(time_since, time_until)
 
             serie_map = {}
             names = []

--- a/admin_tools_stats/models.py
+++ b/admin_tools_stats/models.py
@@ -567,7 +567,7 @@ class CriteriaToStatsM2M(models.Model):
         return query.resolve_ref(field_name).field
 
     # The slef argument is here just because of this bug: https://github.com/infoscout/django-cache-utils/issues/19
-    # @cached(60 * 5)
+    @cached(60 * 5)
     def _get_dynamic_choices(self, slef, time_since=None, time_until=None):
         model = self.stats.get_model()
         field_name = self.get_dynamic_criteria_field_name()

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -67,7 +67,7 @@ class ChartDataView(TemplateView):
             return context
         criteria = dashboard_stats.get_multi_series_criteria(self.request.GET)
         if criteria:
-            choices = criteria.get_dynamic_choices()
+            choices = criteria.get_dynamic_choices(time_since, time_until)
         else:
             choices = {}
 


### PR DESCRIPTION
Hi,
I made a quick fix for myself to filter the keys shown on charts to reflect only values that actually exist during that timeframe, because otherwise there was way too many values to actually look at the chart. If you think this could be useful, feel free to merge. 
The tests fail with "dictionary update sequence element #0 has length 1; 2 is required", but that also fails on the revision that I built upon, so I didn't go more into that for now.

Děkuju for the good work! 