### PR TITLE
Fix tooltip issues by properly cleaning up chart instances

### DIFF
--- a/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
+++ b/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
@@ -3,6 +3,34 @@ var html_string = '<svg style="width:100%;height:400px"></svg>';
 var html_string_analytics = '<svg style="width:100%;height:100%"></svg>';
 var chart_scripts = {};
 
+function cleanupChart(graph_key) {
+   d3.selectAll('.nvtooltip').remove();
+
+   const containerId = 'chart_container_' + graph_key;
+   const container = document.getElementById(containerId);
+   if (container) {
+      const svg = container.querySelector('svg');
+      if (svg) {
+         d3.select(svg).on('.zoom', null);
+         d3.select(svg).selectAll('*').on('.nv', null);
+      }
+   }
+
+   if (window.nv && window.nv.graphs) {
+      window.nv.graphs = window.nv.graphs.filter(function(g) {
+         if (!g || !g.generate) {
+            return true;
+         }
+         const chart = typeof g.generate === 'function' ? g.generate() : g.generate;
+         if (!chart || !chart.container) {
+            return true;
+         }
+         const chartContainer = typeof chart.container === 'function' ? chart.container() : chart.container;
+         return chartContainer !== container;
+      });
+   }
+}
+
 function getChartParamsFromUrl(graph_key) {
    const urlParams = new URLSearchParams(window.location.search);
    const params = {};
@@ -135,9 +163,9 @@ function loadAnchor(){
    data.addClass("loading");
    var graph_key = data.find(".hidden_graph_key").first().val();
    var is_analytics = data.closest('.chrt_flex').length > 0;
-   if($(this).hasClass('select_box_chart_type') || $(this).hasClass('stateform')){
-      $("#chart_container_" + graph_key).empty().append(is_analytics ? html_string_analytics : html_string);
-   };
+
+   cleanupChart(graph_key);
+   $("#chart_container_" + graph_key).empty().append(is_analytics ? html_string_analytics : html_string);
 
    updateAnalyticsLink(data, graph_key);
    loadChart(data, graph_key, reload, is_analytics);

--- a/admin_tools_stats/templates/admin_tools_stats/analytics.html
+++ b/admin_tools_stats/templates/admin_tools_stats/analytics.html
@@ -12,80 +12,257 @@
          {% if request.GET.show %}
             loadAnalyticsChart('{{ request.GET.show }}');
          {% endif %}
+
+         function closeMenu() {
+            $('#chartSidebar').removeClass('open');
+            $('#menuOverlay').removeClass('open');
+         }
+
+         $('#menuToggle').click(function() {
+            $('#chartSidebar').toggleClass('open');
+            $('#menuOverlay').toggleClass('open');
+         });
+
+         $('#menuOverlay').click(closeMenu);
+
          $(".change_chart_button").click(function(){
             const chartKey = $(this).data("chart-key");
             const urlParams = new URLSearchParams(window.location.search);
             urlParams.set('show', chartKey);
             window.history.pushState({}, '', window.location.pathname + '?' + urlParams.toString());
             loadAnalyticsChart(chartKey);
+            closeMenu();
             return false;
+         });
+
+         let resizeTimer;
+         $(window).on('resize', function() {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(function() {
+               $('.admin_charts:visible form.stateform').each(function() {
+                  const $form = $(this);
+                  const graphKey = $form.find(".hidden_graph_key").first().val();
+                  if (graphKey) {
+                     cleanupChart(graphKey);
+                     $("#chart_container_" + graphKey).empty().append(html_string_analytics);
+                     loadChart($form, graphKey, false, true);
+                  }
+               });
+            }, 300);
          });
       });
    </script>
 
    <style>
-   .admin_charts {
-       padding: 0px 0px;
-   }
-   .chrt_container svg {
-        bottom: 0px !important;
-   }
-   #content, .chrt_container {
-        flex-grow: 1;
+   html {
+      height: 100%;
    }
    body {
-      position: absolute;
-      top: 0px;
-      bottom: 0px;
-   }
-   #container, .chrt_flex {
-      display: flex !important;
-      flex-direction: column !important;
-   }
-   #container, .admin_charts, .chrt_flex, .chrt_container, .chrt_svg_container {
       height: 100%;
+      margin: 0;
+      overflow: hidden;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+   }
+   #container {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+   }
+   main {
+      flex: 1 !important;
+      min-height: 0 !important;
+      height: calc(100vh - 60px) !important;
       position: relative;
+      display: flex;
+      flex-direction: row;
+      overflow: hidden;
+   }
+   .colM {
+      flex: 1;
+      display: flex;
+      flex-direction: row;
+      min-height: 0;
+      overflow: hidden;
+   }
+   .chart-selector-sidebar {
+      width: 220px;
+      flex-shrink: 0;
+      overflow-y: auto;
+      padding: 10px;
+      background: #f8f8f8;
+      border-right: 1px solid #ddd;
+      box-sizing: border-box;
+   }
+   .chart-selector-sidebar button {
+      display: block;
+      width: 100%;
+      margin-bottom: 5px;
+      text-align: left;
+      padding: 8px 10px;
+      border: 1px solid #ccc;
+      background: white;
+      cursor: pointer;
+   }
+   .chart-selector-sidebar button:hover {
+      background: #e8f4f8;
+   }
+   .chart-content-area {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      min-height: 0;
+      overflow-y: auto;
+   }
+
+   .breadcrumbs {
+      display: flex !important;
+      align-items: center;
+   }
+   .menu-toggle {
+      display: none;
+      padding: 6px 12px;
+      background: #417690;
+      color: white;
+      border: 1px solid rgba(255,255,255,0.3);
+      cursor: pointer;
+      font-size: 13px;
+      border-radius: 3px;
+      line-height: 1;
+      white-space: nowrap;
+   }
+   .menu-toggle:hover {
+      background: #2e5266;
+   }
+
+   @media (max-width: 768px) {
+      main {
+         height: auto !important;
+         max-height: none !important;
+         overflow: visible !important;
+      }
+      .breadcrumbs {
+         position: relative;
+      }
+      .menu-toggle {
+         display: inline-block !important;
+         position: absolute;
+         right: 10px;
+         top: -35px;
+         z-index: 100;
+      }
+      .chart-selector-sidebar {
+         position: absolute;
+         left: -240px;
+         top: 0;
+         bottom: 0;
+         width: 220px;
+         z-index: 100;
+         transition: left 0.3s ease;
+         border-right: none;
+         box-shadow: 2px 0 5px rgba(0,0,0,0.2);
+      }
+      .chart-selector-sidebar.open {
+         left: 0;
+      }
+      .menu-overlay {
+         display: none;
+         position: absolute;
+         top: 0;
+         left: 0;
+         right: 0;
+         bottom: 0;
+         background: rgba(0,0,0,0.5);
+         z-index: 99;
+      }
+      .menu-overlay.open {
+         display: block;
+      }
+      .chart-content-area {
+         width: 100%;
+      }
+   }
+   .admin_charts {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+   }
+   .chrt_container {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+   }
+   .chrt_flex {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+   }
+   .chrt_flex h3 {
+      flex-shrink: 0;
+      margin: 10px;
+   }
+   .chrt_flex form {
+      flex-shrink: 0;
+      padding: 0 10px;
+   }
+   .chrt_flex form select,
+   .chrt_flex form input[type="text"],
+   .chrt_flex form input[type="date"] {
+      max-width: 200px;
+   }
+   .chrt_svg_container {
+      flex: 1;
+      min-height: 0;
+   }
+   .chrt_svg_container svg {
+      width: 100% !important;
+      height: 100% !important;
    }
 
    .modal {
-    display:    none;
-    position:   fixed;
-    z-index:    1000;
-    top:        0;
-    left:       0;
-    height:     100%;
-    width:      100%;
-    background: rgba( 255, 255, 255, .8 )
-                url('http://i.stack.imgur.com/FhHRx.gif')
-                50% 50%
-                no-repeat;
-    }
-
-    /* When the body has the loading class, we turn
-       the scrollbar off with overflow:hidden */
-    body.loading .modal {
-        overflow: hidden;
-    }
-
-    /* Anytime the body has the loading class, our
-       modal element will be visible */
-    body.loading .modal {
-        display: block;
-    }
+      display: none;
+      position: fixed;
+      z-index: 1000;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+      background: rgba(255, 255, 255, .8)
+                  url('http://i.stack.imgur.com/FhHRx.gif')
+                  50% 50%
+                  no-repeat;
+   }
+   body.loading .modal {
+      overflow: hidden;
+      display: block;
+   }
    </style>
 {% endblock %}
 
 {% block content %}
-   {% for chart in nonuser_charts %}
-   <a class="change_chart_button" href="?show={{ chart.graph_key }}" data-chart-key="{{ chart.graph_key }}"><button>{{ chart.graph_title }}</button></a>
-   {% empty %}
-      <p>
-         No charts available, please <a href="{% url 'admin:admin_tools_stats_dashboardstats_changelist' %}">configure them</a>
-      </p>
-   {% endfor %}
-   {% for chart in charts %}
-   <div class="admin_charts notloaded" id="chart_element_{{ chart.graph_key }}" data-chart-key="{{ chart.graph_key }}">
+   <button class="menu-toggle" id="menuToggle">☰ Charts</button>
+   <div class="menu-overlay" id="menuOverlay"></div>
+   <div class="chart-selector-sidebar" id="chartSidebar">
+      {% for chart in nonuser_charts %}
+      <a class="change_chart_button" href="?show={{ chart.graph_key }}" data-chart-key="{{ chart.graph_key }}"><button>{{ chart.graph_title }}</button></a>
+      {% empty %}
+         <p>
+            No charts available, please <a href="{% url 'admin:admin_tools_stats_dashboardstats_changelist' %}">configure them</a>
+         </p>
+      {% endfor %}
    </div>
-   {% endfor %}
+   <div class="chart-content-area">
+      {% for chart in charts %}
+      <div class="admin_charts notloaded" id="chart_element_{{ chart.graph_key }}" data-chart-key="{{ chart.graph_key }}">
+      </div>
+      {% endfor %}
+   </div>
    <div class="modal">
 {% endblock %}

--- a/admin_tools_stats/tests/test_views.py
+++ b/admin_tools_stats/tests/test_views.py
@@ -247,6 +247,7 @@ class ChartDataViewContextTests(BaseSuperuserAuthenticatedClient):
                     ],
                     "y0": [0, 1, 0, 0, 0],
                 },
+                "graph_key": "user_graph",
                 "view": chart_data_view,
             },
         )
@@ -301,6 +302,7 @@ class ChartDataViewContextTests(BaseSuperuserAuthenticatedClient):
                     ],
                     "y0": [0, 1, 1, 1, 1, 1, 0, 0],
                 },
+                "graph_key": "user_graph",
                 "view": chart_data_view,
             },
         )
@@ -356,8 +358,9 @@ class ChartDataViewContextTests(BaseSuperuserAuthenticatedClient):
                         1635980400000,
                         1636066800000,  # 2021-11-04 23:00:00 GMT
                     ],
-                    "y0": [0, 150, 160, 170, 180, 200, 0, 0],
+                    "y0": [0, 150.0, 160.0, 170.0, 180.0, 200.0, 0, 0],
                 },
+                "graph_key": "kid_graph",
                 "view": chart_data_view,
             },
         )

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -200,6 +200,7 @@ class ChartDataView(ChartDataMixin, TemplateView):
         }
 
         context["chart_container"] = "chart_container_" + graph_key
+        context["graph_key"] = graph_key
         return context
 
 


### PR DESCRIPTION
- Add cleanupChart function to remove old tooltips and event handlers
- Clean up D3 zoom and NV event listeners before recreating charts
- Remove chart instances from global registry when reloading
- Call cleanupChart before every chart reload to prevent tooltip accumulation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds D3/NVD3 chart cleanup and reload flow, overhauls analytics UI with a responsive sidebar and resize-aware redraws, and updates context/tests (incl. graph_key and float values).
> 
> - **Frontend (JS)**:
>   - **Chart cleanup**: Add `cleanupChart()` to remove `nvtooltip`, detach D3 zoom/NVD3 handlers, and prune `window.nv.graphs` for the target container.
>   - **Reload flow**: Always call `cleanupChart(graph_key)` and reinsert SVG before `loadChart()`; keep URL params synced in analytics mode; add CSV download handler.
>   - **Resize handling**: On window resize, cleanup and redraw visible analytics charts.
> - **Templates/UI (`analytics.html`)**:
>   - **Responsive layout**: Introduce sidebar chart selector with toggle button and overlay; restructure content into sidebar + scrollable chart area; mobile styles.
> - **Backend (`views.py`)**:
>   - Include `graph_key` in `ChartDataView` context.
> - **Tests**:
>   - Expect `graph_key` in context and float `y0` values; add comprehensive CSV download tests and a cached-values timezone bug reproduction test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 300e51bffdbd3ea6e01a4b2e3291696301ac5028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->