### PR TITLE
Add chart settings header rows to CSV export

### DIFF
--- a/admin_tools_stats/tests/test_views.py
+++ b/admin_tools_stats/tests/test_views.py
@@ -595,8 +595,42 @@ class CSVDownloadSuperuserTests(BaseSuperuserAuthenticatedClient):
 
         content = response.content.decode("utf-8")
         lines = content.strip().split("\r\n")
-        self.assertTrue(len(lines) >= 2)
-        self.assertIn("Date", lines[0])
+        self.assertTrue(len(lines) >= 4)
+        self.assertIn("Graph Key", lines[0])
+        self.assertIn("user_graph", lines[1])
+        self.assertIn("Date", lines[2])
+
+    @override_settings(USE_TZ=True, TIME_ZONE="UTC")
+    def test_csv_download_settings_headers(self):
+        baker.make("User", date_joined=datetime(2010, 10, 10, tzinfo=timezone.utc))
+        url = reverse("chart-csv", kwargs={"graph_key": "user_graph"})
+        url += (
+            "?time_since=2010-10-08&time_until=2010-10-12"
+            "&select_box_interval=days&select_box_chart_type=discreteBarChart"
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode("utf-8")
+        lines = content.strip().split("\r\n")
+        settings_labels = lines[0].split(",")
+        settings_values = lines[1].split(",")
+
+        self.assertIn("Graph Key", settings_labels)
+        self.assertIn("Graph Title", settings_labels)
+        self.assertIn("Model", settings_labels)
+        self.assertIn("Date Field", settings_labels)
+        self.assertIn("Time Since", settings_labels)
+        self.assertIn("Time Until", settings_labels)
+        self.assertIn("Interval", settings_labels)
+        self.assertIn("Chart Type", settings_labels)
+
+        self.assertIn("user_graph", settings_values)
+        self.assertIn("User Graph", settings_values)
+        self.assertIn("auth.User", settings_values)
+        self.assertIn("date_joined", settings_values)
+        self.assertIn("days", settings_values)
+        self.assertIn("discreteBarChart", settings_values)
 
     @override_settings(USE_TZ=True, TIME_ZONE="UTC")
     def test_csv_download_content_validation(self):
@@ -611,11 +645,11 @@ class CSVDownloadSuperuserTests(BaseSuperuserAuthenticatedClient):
 
         content = response.content.decode("utf-8")
         lines = content.strip().split("\r\n")
-        header = lines[0].split(",")
+        header = lines[2].split(",")
         self.assertEqual(header[0], "Date")
 
-        if len(lines) > 1:
-            data_row = lines[1].split(",")
+        if len(lines) > 3:
+            data_row = lines[3].split(",")
             self.assertIn("2010-10-10", data_row[0])
 
     @override_settings(USE_TZ=True, TIME_ZONE="UTC")
@@ -651,7 +685,7 @@ class CSVDownloadSuperuserTests(BaseSuperuserAuthenticatedClient):
 
         content = response.content.decode("utf-8")
         lines = content.strip().split("\r\n")
-        header = lines[0]
+        header = lines[2]
         self.assertIn("Date", header)
         self.assertIn("Active", header)
         self.assertIn("Inactive", header)
@@ -669,7 +703,7 @@ class CSVDownloadSuperuserTests(BaseSuperuserAuthenticatedClient):
 
         content = response.content.decode("utf-8")
         lines = content.strip().split("\r\n")
-        self.assertTrue(len(lines) >= 2)
+        self.assertTrue(len(lines) >= 4)
 
     @override_settings(USE_TZ=True, TIME_ZONE="UTC")
     def test_csv_download_cached_values(self):
@@ -697,7 +731,7 @@ class CSVDownloadSuperuserTests(BaseSuperuserAuthenticatedClient):
 
         content = response.content.decode("utf-8")
         lines = content.strip().split("\r\n")
-        self.assertTrue(len(lines) >= 2)
+        self.assertTrue(len(lines) >= 4)
 
     @override_settings(USE_TZ=True, TIME_ZONE="UTC")
     def test_csv_download_invalid_date_range(self):
@@ -849,12 +883,19 @@ class CachedChartsBugReproductionTests(BaseSuperuserAuthenticatedClient):
         content = response_csv.content.decode("utf-8")
         lines = content.strip().split("\r\n")
 
-        for line in lines[1:]:
-            if not line or ",0" in line:
+        for line in lines[3:]:
+            if not line:
                 continue
-            date_str = line.split(",")[0]
+            parts = line.split(",")
+            if len(parts) < 2:
+                continue
+            date_str = parts[0]
+            value_str = parts[1]
+
+            if value_str == "0" or value_str == "0.0":
+                continue
+
             date_obj = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
-            value_str = line.split(",")[1]
 
             if "100" in value_str:
                 self.assertEqual(

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -214,6 +214,9 @@ class ChartDataCSVView(ChartDataMixin, View):
         series = chart_data["series"]
         time_since = chart_data["time_since"]
         time_until = chart_data["time_until"]
+        selected_interval = chart_data["selected_interval"]
+        chart_type = chart_data["chart_type"]
+        configuration = chart_data["configuration"]
 
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = (
@@ -222,6 +225,42 @@ class ChartDataCSVView(ChartDataMixin, View):
         )
 
         writer = csv.writer(response)
+
+        settings_labels = [
+            "Graph Key",
+            "Graph Title",
+            "Model",
+            "Date Field",
+            "Time Since",
+            "Time Until",
+            "Interval",
+            "Chart Type",
+            "Operation",
+            "Operation Field",
+        ]
+        settings_values = [
+            dashboard_stats.graph_key,
+            dashboard_stats.graph_title,
+            f"{dashboard_stats.model_app_name}.{dashboard_stats.model_name}",
+            dashboard_stats.date_field_name,
+            time_since.strftime("%Y-%m-%d %H:%M:%S"),
+            time_until.strftime("%Y-%m-%d %H:%M:%S"),
+            selected_interval.value,
+            chart_type,
+            request.GET.get(
+                "select_box_operation", dashboard_stats.type_operation_field_name or ""
+            ),
+            request.GET.get(
+                "select_box_operation_field", dashboard_stats.operation_field_name or ""
+            ),
+        ]
+
+        for key, value in configuration.items():
+            settings_labels.append(key)
+            settings_values.append(str(value) if value else "")
+
+        writer.writerow(settings_labels)
+        writer.writerow(settings_values)
 
         serie_keys = set()
         for date_data in series.values():


### PR DESCRIPTION
- CSV export now includes 2 header rows with complete chart configuration
- Row 1: Setting labels (Graph Key, Title, Model, Date Field, etc.)
- Row 2: Setting values corresponding to the current chart state
- Updated all CSV download tests to account for new header rows
- Added comprehensive test for chart settings validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> CSV export now prepends two rows with chart settings metadata; tests updated and a new validation test added.
> 
> - **Backend**:
>   - `ChartDataCSVView.get`: Writes two header rows with chart settings (`Graph Key`, `Graph Title`, `Model`, `Date Field`, `Time Since/Until`, `Interval`, `Chart Type`, `Operation`, `Operation Field`), plus any remaining request configuration. Uses `get_chart_series_data` to fetch `selected_interval`, `chart_type`, and `configuration`.
>   - CSV data header remains as `Date` + series keys after the new settings rows.
> - **Tests**:
>   - Adjust CSV tests (`test_csv_download_*`) to account for two new header rows (index shifts, min line counts).
>   - Add `test_csv_download_settings_headers` to validate presence and values of settings rows.
>   - Update cached values timezone bug reproduction to start parsing after header rows and ignore zero-value rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16796ad2db3529bbea7abc32fcf32d27fecfc11c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->