### PR TITLE
fix(cache): handle DateField keys in cached series finality checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,19 +22,35 @@ jobs:
 
     strategy:
       matrix:
-        DJANGO_VERSION: ['4.2.*', '5.0.*', '5.1.*']
+        DJANGO_VERSION: ['4.2.*', '5.0.*', '5.1.*', '5.2.*', '6.0.*']
         DB_ENGINE: [ 'postgres', 'mysql' ]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         exclude:
           - DJANGO_VERSION: '5.0.*'
             python-version: '3.8'
           - DJANGO_VERSION: '5.0.*'
             python-version: '3.9'
+          - DJANGO_VERSION: '5.0.*'
+            python-version: '3.13'
 
           - DJANGO_VERSION: '5.1.*'
             python-version: '3.8'
           - DJANGO_VERSION: '5.1.*'
             python-version: '3.9'
+          - DJANGO_VERSION: '5.2.*'
+            python-version: '3.8'
+          - DJANGO_VERSION: '5.2.*'
+            python-version: '3.9'
+          - DJANGO_VERSION: '4.2.*'
+            python-version: '3.13'
+          - DJANGO_VERSION: '6.0.*'
+            python-version: '3.8'
+          - DJANGO_VERSION: '6.0.*'
+            python-version: '3.9'
+          - DJANGO_VERSION: '6.0.*'
+            python-version: '3.10'
+          - DJANGO_VERSION: '6.0.*'
+            python-version: '3.11'
       fail-fast: false
 
     services:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.6.0 (2026-02-24)
+------------------
+* fix cached chart reload for DateField-backed series in timezone-aware mode by normalizing finality comparisons to matching date/datetime types
+* add regression tests for DateField cache reload behavior and date-key handling
+* fix test compatibility for Python 3.9 by importing ``patch`` from ``unittest.mock`` directly
+* expand CI matrix with Django 5.2/6.0 and Python 3.13 (with unsupported combinations excluded)
+
 1.5.0 (2025-04-03)
 ------------------
 * project configuration fixes and updates

--- a/admin_tools_stats/models.py
+++ b/admin_tools_stats/models.py
@@ -848,13 +848,15 @@ class DashboardStats(models.Model):
                 i = 0
                 for date, values_dict in values.items():
                     for filtered_value, value in values_dict.items():
-                        is_final = (
-                            truncate(
-                                datetime.datetime.now().astimezone(get_charts_timezone()),
-                                interval.val(),
-                            )
-                            > date
+                        current_period = truncate(
+                            datetime.datetime.now().astimezone(get_charts_timezone()),
+                            interval.val(),
                         )
+                        if isinstance(date, datetime.date) and not isinstance(
+                            date, datetime.datetime
+                        ):
+                            current_period = current_period.date()
+                        is_final = current_period > date
                         bulk += [
                             CachedValue(
                                 **common_options,

--- a/admin_tools_stats/tests/test_models.py
+++ b/admin_tools_stats/tests/test_models.py
@@ -8,6 +8,7 @@
 # The Initial Developer of the Original Code is
 # Arezqui Belaid <info@star2billing.com>
 #
+import unittest
 from collections import OrderedDict
 from datetime import date, datetime, timezone
 from unittest import skipIf
@@ -1800,6 +1801,96 @@ class CacheModelTests(TestCase):
             datetime(2010, 10, 12, 0, 0).astimezone(current_tz): {"": 1},
         }
         self.assertDictEqual(serie, testing_data)
+
+    @override_settings(USE_TZ=True, TIME_ZONE="Europe/Prague")
+    def test_get_multi_series_cached_datefield_tz(self):
+        """DateField series should work with cache + tz without datetime/date compare crash."""
+        stats = baker.make(
+            "DashboardStats",
+            date_field_name="birthday",
+            model_name="TestKid",
+            model_app_name="demoproject",
+            graph_key="kid_graph_cached",
+            cache_values=True,
+        )
+        baker.make("TestKid", birthday=date(2026, 2, 22))
+        user = baker.make("User")
+        time_since = datetime(2026, 2, 21).astimezone(dj_timezone.get_current_timezone())
+        time_until = datetime(2026, 2, 23).astimezone(dj_timezone.get_current_timezone())
+
+        serie = stats.get_multi_time_series_cached(
+            {"reload_all": "True"},
+            time_since,
+            time_until,
+            Interval.days,
+            None,
+            None,
+            user,
+        )
+        self.assertEqual(len(serie), 3)
+        self.assertEqual(sum(v[""] for v in serie.values()), 1)
+
+    @override_settings(USE_TZ=True, TIME_ZONE="Europe/Prague")
+    def test_get_multi_series_cached_datefield_marks_final_flags(self):
+        """DateField cached values are saved with is_final without type errors."""
+        stats = baker.make(
+            "DashboardStats",
+            date_field_name="birthday",
+            model_name="TestKid",
+            model_app_name="demoproject",
+            graph_key="kid_graph_cached_flags",
+            cache_values=True,
+        )
+        baker.make("TestKid", birthday=date(2026, 2, 22))
+        user = baker.make("User")
+        time_since = datetime(2026, 2, 21).astimezone(dj_timezone.get_current_timezone())
+        time_until = datetime(2026, 2, 23).astimezone(dj_timezone.get_current_timezone())
+
+        stats.get_multi_time_series_cached(
+            {"reload_all": "True"},
+            time_since,
+            time_until,
+            Interval.days,
+            None,
+            None,
+            user,
+        )
+
+        cached_values = CachedValue.objects.filter(stats=stats).order_by("date")
+        self.assertEqual(cached_values.count(), 3)
+        self.assertTrue(cached_values.filter(is_final=True).exists())
+        self.assertNotIn(None, cached_values.values_list("is_final", flat=True))
+
+    @override_settings(USE_TZ=True, TIME_ZONE="Europe/Prague")
+    def test_get_multi_series_cached_handles_date_keys_in_reload_values(self):
+        """Reload path accepts date-keyed series and compares finality safely."""
+        stats = baker.make(
+            "DashboardStats",
+            date_field_name="birthday",
+            model_name="TestKid",
+            model_app_name="demoproject",
+            graph_key="kid_graph_cached_date_keys",
+            cache_values=True,
+        )
+        user = baker.make("User")
+        time_since = datetime(2026, 2, 21).astimezone(dj_timezone.get_current_timezone())
+        time_until = datetime(2026, 2, 23).astimezone(dj_timezone.get_current_timezone())
+
+        with unittest.mock.patch.object(
+            DashboardStats,
+            "get_multi_time_series",
+            return_value={date(2026, 2, 22): {"": 1}},
+        ):
+            serie = stats.get_multi_time_series_cached(
+                {"reload_all": "True"},
+                time_since,
+                time_until,
+                Interval.days,
+                None,
+                None,
+                user,
+            )
+        self.assertEqual(len(serie), 1)
 
 
 class DashboardStatsTest(TestCase):

--- a/admin_tools_stats/tests/test_models.py
+++ b/admin_tools_stats/tests/test_models.py
@@ -8,10 +8,10 @@
 # The Initial Developer of the Original Code is
 # Arezqui Belaid <info@star2billing.com>
 #
-import unittest
 from collections import OrderedDict
 from datetime import date, datetime, timezone
 from unittest import skipIf
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -1876,7 +1876,7 @@ class CacheModelTests(TestCase):
         time_since = datetime(2026, 2, 21).astimezone(dj_timezone.get_current_timezone())
         time_until = datetime(2026, 2, 23).astimezone(dj_timezone.get_current_timezone())
 
-        with unittest.mock.patch.object(
+        with patch.object(
             DashboardStats,
             "get_multi_time_series",
             return_value={date(2026, 2, 22): {"": 1}},

--- a/admin_tools_stats/tests/utils.py
+++ b/admin_tools_stats/tests/utils.py
@@ -31,11 +31,21 @@ def assertContainsAny(
     msg_prefix="",
     html=False,
 ):
-    total_count = 0
+    errors = []
     for text in texts:
-        args = self._assert_contains(response, text, status_code, msg_prefix, html)
-        real_count = args[1]
-        msg_prefix = args[2]
-        total_count += real_count
+        try:
+            self.assertContains(
+                response,
+                text,
+                status_code=status_code,
+                msg_prefix=msg_prefix,
+                html=html,
+            )
+            return
+        except AssertionError as error:
+            errors.append(str(error))
 
-    self.assertTrue(total_count != 0, f"None of the {texts} were found in the response: {response}")
+    self.fail(
+        f"None of the {texts} were found in the response. "
+        f"Assertion errors: {' | '.join(errors)}"
+    )

--- a/demoproject/demoproject/settings.py
+++ b/demoproject/demoproject/settings.py
@@ -2,10 +2,24 @@
 
 import os
 import sys
+import types
+from collections.abc import Iterable
 from typing import List
 
 
 DEBUG = True
+
+# django-admin-tools imports django.utils.itercompat, removed in newer Django.
+# Provide a tiny compatibility shim so demo/test project can still load apps.
+itercompat_module = types.ModuleType("django.utils.itercompat")
+
+
+def _is_iterable(value):
+    return isinstance(value, Iterable)
+
+
+itercompat_module.is_iterable = _is_iterable
+sys.modules.setdefault("django.utils.itercompat", itercompat_module)
 
 APPLICATION_DIR = os.path.dirname(globals()["__file__"])
 

--- a/demoproject/demoproject/settings.py
+++ b/demoproject/demoproject/settings.py
@@ -18,7 +18,7 @@ def _is_iterable(value):
     return isinstance(value, Iterable)
 
 
-itercompat_module.is_iterable = _is_iterable
+setattr(itercompat_module, "is_iterable", _is_iterable)
 sys.modules.setdefault("django.utils.itercompat", itercompat_module)
 
 APPLICATION_DIR = os.path.dirname(globals()["__file__"])


### PR DESCRIPTION
Normalize truncated current period to date when cached series values are keyed by DateField buckets, preventing datetime/date comparison errors during cached reloads. Add DateField cache regression tests covering timezone mode and date-key reload behavior.