### PR TITLE
fix(models): use the full criteria path for count-limited choices [Blenderkit Sentry error regression]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ unreleased
 * add ``Median`` operation, computed by the ``PERCENTILE_CONT`` ordered-set aggregate (PostgreSQL/Oracle; raises ``NotSupportedError`` on MySQL and SQLite)
 * fix mypy failure with current django-stubs: ``check_chart_permission()`` accepts the ``AnonymousUser`` it is already called with
 * fix 500 on charts aggregating a ``DecimalField``: ``Decimal`` y values are converted to ``float`` before the series reaches ``python-nvd3``'s ``json.dumps()``
+* fix ``FieldError`` when a count-limited multiple-series criteria points to a related model: the limited choices query is built on the chart's own model, so it needs the full criteria path, not the related model's field name
 
 1.6.0 (2026-02-24)
 ------------------

--- a/admin_tools_stats/models.py
+++ b/admin_tools_stats/models.py
@@ -1078,6 +1078,10 @@ class CriteriaToStatsM2M(models.Model):
                     str, Tuple[Union[None, str, bool, List[str]], Optional[str]]
                 ] = OrderedDict()
                 fchoices: Dict[str, str] = dict(field.choices or [])
+                # the name the values are ordered by: the criteria path is
+                # relative to the chart's own model, the related model knows
+                # only the last segment of it
+                order_field_name = field_name
                 if self.choices_based_on_time_range:
                     choices_queryset = self.stats.get_queryset()
                     if queryset_filter:
@@ -1096,10 +1100,11 @@ class CriteriaToStatsM2M(models.Model):
                     ).distinct()
                 else:
                     # Obtain the related model and the target field dynamically from the field_name
-                    related_model, field_name = self.get_related_model_and_field(field_name)
+                    related_model, related_field_name = self.get_related_model_and_field(field_name)
+                    order_field_name = related_field_name
 
                     choices_queryset = related_model.objects.values_list(
-                        field_name,  # targeting the final field in the related model
+                        related_field_name,  # targeting the final field in the related model
                         flat=True,
                     ).distinct()
 
@@ -1121,7 +1126,7 @@ class CriteriaToStatsM2M(models.Model):
                     other_choices_queryset: List[str] = choices_list[count_limit:]
                     choices_queryset = choices_list[:count_limit]
                 else:
-                    choices_queryset = choices_queryset.order_by(field_name)
+                    choices_queryset = choices_queryset.order_by(order_field_name)
                 choices.update(
                     ((i, (i, fchoices[i] if i in fchoices else i)) for i in choices_queryset),
                 )

--- a/admin_tools_stats/tests/test_models.py
+++ b/admin_tools_stats/tests/test_models.py
@@ -1136,6 +1136,93 @@ class ModelTests(TestCase):
         "no support of USE_TZ=False in mysql",
     )
     @override_settings(USE_TZ=False)
+    def test_get_multi_series_chart_filter_blank_value(self):
+        """
+        Test function to check DashboardStats.get_multi_time_series()
+        A blank chart_filter value is the "All" option and filters nothing
+        """
+        criteria = baker.make(
+            "DashboardStatsCriteria",
+            criteria_name="name",
+            dynamic_criteria_field_name="last_name",
+        )
+        m2m = baker.make(
+            "CriteriaToStatsM2M",
+            criteria=criteria,
+            stats=self.stats,
+            use_as="chart_filter",
+        )
+        baker.make("User", date_joined=date(2010, 10, 12), last_name="Foo")
+        baker.make("User", date_joined=date(2010, 10, 12), last_name="Bar")
+        user = baker.make("User", is_superuser=True)
+
+        serie = self.stats.get_multi_time_series(
+            {"select_box_dynamic_%s" % m2m.id: ""},
+            datetime(2010, 10, 11),
+            datetime(2010, 10, 13),
+            Interval.days,
+            None,
+            None,
+            user,
+        )
+        self.assertDictEqual(
+            serie,
+            {
+                datetime(2010, 10, 11, 0, 0): {"": 0},
+                datetime(2010, 10, 12, 0, 0): {"": 2},
+                datetime(2010, 10, 13, 0, 0): {"": 0},
+            },
+        )
+
+    @skipIf(
+        settings.DATABASES["default"]["ENGINE"] == "django.db.backends.mysql",
+        "no support of USE_TZ=False in mysql",
+    )
+    @override_settings(USE_TZ=False)
+    def test_get_multi_series_chart_filter_value_outside_choices(self):
+        """
+        Test function to check DashboardStats.get_multi_time_series()
+        A chart_filter value that is not among the choices - a stale bookmarked
+        URL, or a value that dropped out of a count-limited list - is applied as
+        a plain filter value instead of raising
+        """
+        criteria = baker.make(
+            "DashboardStatsCriteria",
+            criteria_name="name",
+            dynamic_criteria_field_name="last_name",
+        )
+        m2m = baker.make(
+            "CriteriaToStatsM2M",
+            criteria=criteria,
+            stats=self.stats,
+            use_as="chart_filter",
+        )
+        baker.make("User", date_joined=date(2010, 10, 12), last_name="Foo")
+        user = baker.make("User", is_superuser=True)
+
+        serie = self.stats.get_multi_time_series(
+            {"select_box_dynamic_%s" % m2m.id: "Nobody"},
+            datetime(2010, 10, 11),
+            datetime(2010, 10, 13),
+            Interval.days,
+            None,
+            None,
+            user,
+        )
+        self.assertDictEqual(
+            serie,
+            {
+                datetime(2010, 10, 11, 0, 0): {"": 0},
+                datetime(2010, 10, 12, 0, 0): {"": 0},
+                datetime(2010, 10, 13, 0, 0): {"": 0},
+            },
+        )
+
+    @skipIf(
+        settings.DATABASES["default"]["ENGINE"] == "django.db.backends.mysql",
+        "no support of USE_TZ=False in mysql",
+    )
+    @override_settings(USE_TZ=False)
     def test_get_multi_series_criteria_combine(self):
         """
         Test function to check DashboardStats.get_multi_time_series()

--- a/admin_tools_stats/tests/test_models.py
+++ b/admin_tools_stats/tests/test_models.py
@@ -34,6 +34,7 @@ from admin_tools_stats.models import (
     Interval,
     truncate_ceiling,
 )
+from demoproject.demoproject.models import TestKid
 
 
 try:
@@ -583,6 +584,62 @@ class ModelTests(TestCase):
                 self.assertDictEqual(serie, testing_data)
 
                 # Clear for next run
+                User.objects.all().delete()
+
+    @skipIf(
+        settings.DATABASES["default"]["ENGINE"] == "django.db.backends.mysql",
+        "no support of USE_TZ=False in mysql",
+    )
+    @override_settings(USE_TZ=False)
+    def test_get_multi_series_count_limit_related_field(self):
+        """
+        Test function to check DashboardStats.get_multi_time_series()
+        Choices are limited by count and the criteria points to a related model
+        """
+        for choices_time_range in (True, False):
+            with self.subTest(choices_time_range):
+                cache.clear()
+                criteria = baker.make(
+                    "DashboardStatsCriteria",
+                    criteria_name="name",
+                    dynamic_criteria_field_name="first_name",
+                )
+                m2m = baker.make(
+                    "CriteriaToStatsM2M",
+                    criteria=criteria,
+                    stats=self.kid_stats,
+                    prefix="author__",
+                    use_as="multiple_series",
+                    count_limit=1,
+                    choices_based_on_time_range=choices_time_range,
+                )
+                petr = baker.make("User", first_name="Petr", is_superuser=True)
+                adam = baker.make("User", first_name="Adam")
+                baker.make("TestKid", author=petr, birthday=date(2010, 10, 10))
+                baker.make("TestKid", author=petr, birthday=date(2010, 10, 10))
+                baker.make("TestKid", author=adam, birthday=date(2010, 10, 9))
+                time_since = datetime(2010, 10, 8)
+                time_until = datetime(2010, 10, 11)
+
+                serie = self.kid_stats.get_multi_time_series(
+                    {"select_box_multiple_series": m2m.id},
+                    time_since,
+                    time_until,
+                    Interval.days,
+                    None,
+                    None,
+                    petr,
+                )
+                testing_data = {
+                    date(2010, 10, 8): {"other": 0, "Petr": 0, None: 0},
+                    date(2010, 10, 9): {"other": 1, "Petr": 0, None: 0},
+                    date(2010, 10, 10): {"other": 0, "Petr": 2, None: 0},
+                    date(2010, 10, 11): {"other": 0, "Petr": 0, None: 0},
+                }
+                self.assertDictEqual(serie, testing_data)
+
+                # Clear for next run
+                TestKid.objects.all().delete()
                 User.objects.all().delete()
 
     @skipIf(


### PR DESCRIPTION
## Problem

`CriteriaToStatsM2M._get_dynamic_choices()` rebinds its own `field_name` while resolving the related model:

```python
related_model, field_name = self.get_related_model_and_field(field_name)
```

From that line on, `field_name` is the **last segment** of the path (`"first_name"`) instead of the path itself (`"author__first_name"`). The related-model query wants the short name — but the `count_limit` branch immediately below queries the *chart's own* model, where only the full path resolves:

```python
if count_limit:
    choices_queryset = self.stats.get_queryset().values_list(field_name, flat=True).distinct()
```

```
django.core.exceptions.FieldError: Cannot resolve keyword 'first_name' into field.
Choices are: age, appointment, author, author_id, bio, birthday, happy, height, id, name, wanted_games_qtd
```

So any multiple-series criteria that **both** traverses a relation (directly or via `prefix`) **and** sets `count_limit` raises. The existing `count_limit` test only uses a local field on the chart's own model, where `get_related_model_and_field()` returns the name unchanged — which is why this went unnoticed.

Impact depends on where it fires: in a chart request it is an error box, but in `recalculate_charts` the exception kills the whole run, so every chart queued after the broken one keeps serving stale cached values. That is how we found it — one criterion of that shape has been failing our monthly/weekly recalculation since May.

## Fix

Keep the related model's field name in its own variable and leave `field_name` as the criteria path. The ordering of the non-limited branch follows whichever queryset it was already ordering (`order_field_name`), so local-field criteria behave exactly as before.

## Tests

`test_get_multi_series_count_limit_related_field` — the demo `TestKid` → `author` relation via `prefix="author__"` with `count_limit=1`, run for both `choices_based_on_time_range` values. The cache is cleared per sub-test so the memoized choices of one cannot mask the other (without that, the working branch's cached result hides the broken one).

Against the unfixed code the `False` sub-test raises the production `FieldError`; with the fix both pass. 104 tests green on SQLite and PostgreSQL; flake8/isort clean.

## Aside, not touched here

`admin_tools_stats/management/commands/recalculate_charts.py` on `master` imports `blenderhub.apps.accounts.models` and looks up a hardcoded e-mail address, so the command cannot run outside that one project. Out of scope for this PR, but worth a follow-up (e.g. a `--user` argument defaulting to any superuser).
