### PR TITLE
fix(typing): accept AnonymousUser in check_chart_permission [Blenderkit Sentry error regression]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 unreleased
 ----------
 * add ``Median`` operation, computed by the ``PERCENTILE_CONT`` ordered-set aggregate (PostgreSQL/Oracle; raises ``NotSupportedError`` on MySQL and SQLite)
+* fix mypy failure with current django-stubs: ``check_chart_permission()`` accepts the ``AnonymousUser`` it is already called with
 
 1.6.0 (2026-02-24)
 ------------------

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from datetime_truncate import truncate
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.contrib.auth.models import User
+from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpRequest, HttpResponse
 from django.views.generic import TemplateView, View
 
@@ -52,7 +52,9 @@ def remove_multiple_keys(in_dict, entries_to_remove):
 
 
 class ChartDataMixin:
-    def check_chart_permission(self, dashboard_stats: DashboardStats, user: User) -> bool:
+    def check_chart_permission(
+        self, dashboard_stats: DashboardStats, user: Union[User, AnonymousUser]
+    ) -> bool:
         return (
             user.has_perm("admin_tools_stats.view_dashboardstats") or dashboard_stats.show_to_users
         )


### PR DESCRIPTION
## Problem

`mypy .` is red on `master` right now, which fails the `lint` job of every open PR:

```
admin_tools_stats/views.py:133: error: Argument 2 to "check_chart_permission" of
"ChartDataMixin" has incompatible type "User | AnonymousUser"; expected "User"  [arg-type]
```

Nothing changed in the code — `master`'s last CI run (February) was green. CI installs `test_requirements.txt` unpinned, so a newer mypy/django-stubs simply started checking this call site.

## Fix

`check_chart_permission()` is called with `self.request.user`, i.e. `User | AnonymousUser`, but was annotated `User`. Only the annotation was wrong:

* the body calls `has_perm()`, which `AnonymousUser` implements
* an anonymous user reaching a chart is the normal path for `show_to_users` charts
* `DashboardStats.get_time_series()` in `models.py` already types the same argument as `Union[User, AnonymousUser]`

## Verification

`mypy .` → clean (34 source files). Full suite green (103 tests, SQLite). flake8/isort clean.

Worth merging first: it unblocks the `lint` job on #94, #95 and #96, which are otherwise green across all 36 test jobs.
