### PR TITLE
ci: upload coverage with codecov-action instead of the sunset uploader [Blenderkit Sentry error regression]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,6 @@ jobs:
            pip install --upgrade --upgrade-strategy eager -r demoproject/requirements.txt
            pip install --upgrade --upgrade-strategy eager -r requirements.txt
            pip install --pre Django=='${{ matrix.DJANGO_VERSION }}'
-           pip install codecov
 
       - name: Testing
         run: |
@@ -108,13 +107,22 @@ jobs:
           fi
           python manage.py makemigrations --check --dry-run
           python -W error::DeprecationWarning -m coverage run manage.py test
-          coverage xml && codecov
+          coverage xml
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
           MYSQL_PASSWORD: rootpassword
           MYSQL_USER: root
           DB_ENGINE: ${{ matrix.DB_ENGINE }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: ${{ matrix.DB_ENGINE }}
+          # a Codecov outage must not fail the test matrix
+          fail_ci_if_error: false
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 unreleased
 ----------
+* fix Codecov uploads: replace the sunset ``codecov`` PyPI uploader (tokenless, rate-limited by the 36-job matrix) with ``codecov/codecov-action@v5``
 * add ``Median`` operation, computed by the ``PERCENTILE_CONT`` ordered-set aggregate (PostgreSQL/Oracle; raises ``NotSupportedError`` on MySQL and SQLite)
 * fix mypy failure with current django-stubs: ``check_chart_permission()`` accepts the ``AnonymousUser`` it is already called with
 * fix 500 on charts aggregating a ``DecimalField``: ``Decimal`` y values are converted to ``float`` before the series reaches ``python-nvd3``'s ``json.dumps()``


### PR DESCRIPTION
## Why `codecov/project` fails on PRs that don't lower coverage

Coverage on `master` has been stale since **2025-11-19** (`b8e9000`). Every upload since then has been rejected — from the latest `master` run:

```
Pinging Codecov...
Uploading to Codecov...
{'detail': 'Rate limit reached. Please upload with the Codecov repository
 upload token to resolve issue. Expected time to availability: 1039s.'}
Error: 429 Client Error: Too Many Requests for url:
https://codecov.io/upload/v2?commit=e9528f42...&branch=master
```

The workflow used the sunset `codecov` PyPI uploader (2.1.13) with no token, and **36 matrix jobs** each hit the tokenless endpoint per run — straight into its rate limit. `coverage xml && codecov` still exits 0 after the 429, so the jobs stayed green and nothing surfaced the problem.

The consequence is the confusing part: with no report for any recent `master` commit, Codecov falls back to a base **14 commits behind**, so every PR is diffed against November 2025 coverage and reports a "drop" that is really eight months of master drift. [#96](https://github.com/PetrDlouhy/django-admin-charts/pull/96) is the current example — `codecov/project` fails at -0.31% while Codecov's own comment says *"All modified and coverable lines are covered by tests"*. Locally, `master` and #96 have the **same 37 uncovered statements**; #96 only adds covered ones.

## Change

`codecov/codecov-action@v5`, which uploads with `CODECOV_TOKEN`:

* `flags: ${{ matrix.DB_ENGINE }}` so the mysql and postgres reports stay distinguishable
* `fail_ci_if_error: false` — a Codecov outage must not fail the test matrix
* `pip install codecov` dropped

## Action needed from you

Add the **`CODECOV_TOKEN`** repository secret (*Settings → Secrets and variables → Actions*; the value is on the Codecov repo settings page). Without it the action falls back to the same rate-limited tokenless upload and the reports stay stale.

Once this is on `master` and one `master` run has uploaded, the base becomes current and the `codecov/project` status on open PRs reflects reality on the next run.

## Alternative, if you'd rather not add a secret

Restrict uploading to two designated jobs (one `mysql`, one `postgres`) instead of all 36 — that stays under the tokenless limit. It costs a little accuracy, since a line only exercised on a particular Django/Python combination would then read as uncovered. Say the word and I'll switch it.
