### PR TITLE
fix(recalculate_charts): drop the hardcoded project-specific user [Blenderkit Sentry error regression]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 unreleased
 ----------
 * fix Codecov uploads: replace the sunset ``codecov`` PyPI uploader (tokenless, rate-limited by the 36-job matrix) with ``codecov/codecov-action@v5``
+* ``recalculate_charts`` no longer imports a project-specific model and no longer looks up a hardcoded e-mail address; it takes ``--user`` and otherwise runs as any superuser
 * add ``Median`` operation, computed by the ``PERCENTILE_CONT`` ordered-set aggregate (PostgreSQL/Oracle; raises ``NotSupportedError`` on MySQL and SQLite)
 * fix mypy failure with current django-stubs: ``check_chart_permission()`` accepts the ``AnonymousUser`` it is already called with
 * fix 500 on charts aggregating a ``DecimalField``: ``Decimal`` y values are converted to ``float`` before the series reaches ``python-nvd3``'s ``json.dumps()``

--- a/admin_tools_stats/management/commands/recalculate_charts.py
+++ b/admin_tools_stats/management/commands/recalculate_charts.py
@@ -1,9 +1,9 @@
 import time
 from datetime import datetime, timedelta
 
-from blenderhub.apps.accounts.models import UserProfile
 from datetime_truncate import truncate
-from django.core.management import BaseCommand
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand, CommandError
 
 from admin_tools_stats.models import (
     DashboardStats,
@@ -57,6 +57,35 @@ class Command(BaseCommand):
             default=1,
             type=int,
         )
+        parser.add_argument(
+            "--user",
+            help=(
+                "Username to calculate the charts as. "
+                "Defaults to any superuser; needed because charts can be limited per user."
+            ),
+        )
+
+    def get_user(self, options):
+        """The user the charts are calculated for.
+
+        Charts can be restricted to the logged in user (``user_field_name``) and to
+        the ``view_dashboardstats`` permission, so recalculation needs someone to
+        calculate them as. Any superuser sees everything, which is what a full
+        recalculation wants.
+        """
+        user_model = get_user_model()
+        username = options.get("user", None)
+        if username:
+            try:
+                return user_model.objects.get(**{user_model.USERNAME_FIELD: username})
+            except user_model.DoesNotExist:
+                raise CommandError(f"User '{username}' does not exist")
+        user = user_model.objects.filter(is_superuser=True).order_by("pk").first()
+        if user is None:
+            raise CommandError(
+                "No superuser found to calculate the charts as, pass --user <username>"
+            )
+        return user
 
     def get_all_multiseries_criteria(self, stats, options):
         all_multiseries_criteria = list(
@@ -77,9 +106,9 @@ class Command(BaseCommand):
             for (k, v) in stats_query.values_list("graph_key", "graph_title")
         )
         self.stdout.write(f"recalculating charts: \n{chart_string}")
+        user = self.get_user(options)
         for stats in stats_query:
             operation = stats.type_operation_field_name
-            user = UserProfile.objects.get(email="petr.dlouhy@email.cz")
             configuration = {
                 "select_box_chart_type": stats.default_chart_type,
                 "reload": "True",

--- a/admin_tools_stats/tests/test_commands.py
+++ b/admin_tools_stats/tests/test_commands.py
@@ -1,0 +1,145 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+from datetime import datetime, timezone
+from io import StringIO
+
+from django.contrib.auth.models import User
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+from django.utils.timezone import now
+from model_bakery import baker
+
+from admin_tools_stats.models import CachedValue
+
+
+class RecalculateChartsTests(TestCase):
+    def setUp(self):
+        self.stats = baker.make(
+            "DashboardStats",
+            date_field_name="date_joined",
+            graph_title="Users chart",
+            model_name="User",
+            model_app_name="auth",
+            graph_key="user_graph",
+            type_operation_field_name="Count",
+            operation_field_name="id",
+            cache_values=True,
+            show_to_users=False,
+        )
+        self.superuser = baker.make(
+            "User",
+            username="admin",
+            is_superuser=True,
+            date_joined=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        )
+
+    def call(self, *args, **options):
+        out = StringIO()
+        call_command("recalculate_charts", *args, stdout=out, **options)
+        return out.getvalue()
+
+    def test_recalculate(self):
+        """The command caches the chart values"""
+        baker.make("User", date_joined=datetime(2020, 1, 2, tzinfo=timezone.utc))
+        output = self.call("--time-ranges", "days")
+        self.assertIn("user_graph", output)
+        self.assertIn("Recalculation took", output)
+        self.assertTrue(CachedValue.objects.filter(stats=self.stats).exists())
+
+    def test_dry_run(self):
+        """--dry-run reports what would be recalculated without caching anything"""
+        output = self.call("--time-ranges", "days", "--dry-run")
+        self.assertIn("user_graph", output)
+        self.assertFalse(CachedValue.objects.exists())
+
+    def test_explicit_user(self):
+        """--user selects who the charts are calculated as"""
+        baker.make("User", username="staffer", is_superuser=True)
+        self.call("--time-ranges", "days", "--user", "staffer")
+        self.assertTrue(CachedValue.objects.filter(stats=self.stats).exists())
+
+    def test_unknown_user(self):
+        """--user with an unknown username fails with a clear message"""
+        with self.assertRaises(CommandError) as error:
+            self.call("--time-ranges", "days", "--user", "nobody")
+        self.assertEqual(str(error.exception), "User 'nobody' does not exist")
+
+    def test_no_superuser(self):
+        """Without a superuser the command says what to do instead of failing obscurely"""
+        User.objects.filter(is_superuser=True).delete()
+        with self.assertRaises(CommandError) as error:
+            self.call("--time-ranges", "days")
+        self.assertEqual(
+            str(error.exception),
+            "No superuser found to calculate the charts as, pass --user <username>",
+        )
+
+    def test_graph_key_selects_charts(self):
+        """A graph_key argument limits the run to that chart"""
+        other = baker.make(
+            "DashboardStats",
+            date_field_name="date_joined",
+            graph_title="Other chart",
+            model_name="User",
+            model_app_name="auth",
+            graph_key="other_graph",
+            cache_values=True,
+            show_to_users=False,
+        )
+        self.call("--time-ranges", "days", "user_graph")
+        self.assertTrue(CachedValue.objects.filter(stats=self.stats).exists())
+        self.assertFalse(CachedValue.objects.filter(stats=other).exists())
+
+    def test_recalculates_per_criteria(self):
+        """Charts with criteria are recalculated per multiple-series choice and filter"""
+        criteria = baker.make(
+            "DashboardStatsCriteria",
+            criteria_name="active",
+            dynamic_criteria_field_name="is_active",
+        )
+        baker.make(
+            "CriteriaToStatsM2M",
+            criteria=criteria,
+            stats=self.stats,
+            use_as="chart_filter",
+            default_option="True",
+        )
+        multi = baker.make(
+            "CriteriaToStatsM2M",
+            criteria=criteria,
+            stats=self.stats,
+            use_as="multiple_series",
+            recalculate=True,
+        )
+        baker.make("User", date_joined=datetime(2020, 1, 2, tzinfo=timezone.utc))
+
+        output = self.call("--time-ranges", "days")
+
+        self.assertIn(str(multi), output)
+        self.assertTrue(
+            CachedValue.objects.filter(
+                stats=self.stats, multiple_series_choice=multi.criteria
+            ).exists()
+        )
+
+    def test_defaults_to_the_charts_own_time_scales(self):
+        """Without --time-ranges the chart's allowed time scales are used"""
+        self.stats.allowed_time_scales = ["days"]
+        self.stats.save()
+        baker.make("User", date_joined=now())
+
+        # time_since is always counted back from now, so only a --time-until
+        # near today leaves a non-empty range
+        output = self.call("--time-until", now().strftime("%Y-%m-%d"))
+
+        self.assertIn("in days", output)
+        self.assertTrue(CachedValue.objects.filter(stats=self.stats, time_scale="days").exists())
+
+    def test_exclude(self):
+        """--exclude skips the listed charts"""
+        output = self.call("--time-ranges", "days", "--exclude", "user_graph")
+        self.assertNotIn("user_graph", output)
+        self.assertFalse(CachedValue.objects.exists())


### PR DESCRIPTION
## Release blocker

`recalculate_charts` cannot run anywhere but one specific project:

```python
from blenderhub.apps.accounts.models import UserProfile
...
user = UserProfile.objects.get(email="petr.dlouhy@email.cz")
```

Everywhere else that is an `ImportError` while Django collects commands, so even `manage.py help` fails. It is in the shipped 1.6.0 sdist.

## Change

The command needs *a* user because charts can be restricted per user (`user_field_name`) and by the `view_dashboardstats` permission, so a full recalculation has to run as somebody who sees everything.

* `--user <username>`, resolved through `USERNAME_FIELD` so it works with custom user models
* otherwise the lowest-pk superuser
* both failure modes — unknown username, no superuser — raise `CommandError` saying what to do

## Tests

The command had **no tests at all**, and did not even show up in the coverage report: `.coveragerc` used `include`, which only reports modules that were imported, and nothing imported this one. It is now at 100% — the caching run, `--dry-run`, `--user`, both `CommandError` paths, `graph_key` selection, `--exclude`, per-criteria recalculation and the default time scales.

(The `include` → `source` change that makes such modules visible in general is in a separate PR.)

## Noted, not changed

`--time-until` only works near today: `time_since` is always counted back from `now()`, so an older `--time-until` gives `time_since > time_until` and the run aborts. Widening the window is a behaviour change, not a bugfix — happy to do it separately if you want it.
