### PR TITLE
fix: two crashes on chart configurations nothing tested [Blenderkit Sentry error regression]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ unreleased
 * drop the ``backports.zoneinfo`` fallback and the removed ``dependency_links``/``test_suite`` setup arguments
 * report coverage with ``source`` instead of ``include``, so modules that no test imports show up as 0% instead of being absent from the report; add the missing ``management``/``commands`` ``__init__.py`` that hid the management command from it
 * cover the previously untested paths: the app label renamer, the chart control form's criteria fields, the admin analytics link and per-chart criteria queryset, ``static_or_path``, the userspace analytics template, the reload-all button and pytz-style ``ADMIN_CHARTS_TIMEZONE``
+* fix ``TypeError`` when rendering the chart controls of a chart whose ``allowed_type_operation_field_name`` was never set (the field is nullable and has no default)
+* fix ``KeyError`` breaking the whole admin index when a dashboard holds a ``DashboardChart`` for a graph key that no longer exists or was hidden; it is reported as an admin message, which is what the module already intended
 * add ``Median`` operation, computed by the ``PERCENTILE_CONT`` ordered-set aggregate (PostgreSQL/Oracle; raises ``NotSupportedError`` on MySQL and SQLite)
 * fix mypy failure with current django-stubs: ``check_chart_permission()`` accepts the ``AnonymousUser`` it is already called with
 * fix 500 on charts aggregating a ``DecimalField``: ``Decimal`` y values are converted to ``float`` before the series reaches ``python-nvd3``'s ``json.dumps()``

--- a/admin_tools_stats/forms.py
+++ b/admin_tools_stats/forms.py
@@ -46,7 +46,8 @@ class ChartSettingsForm(forms.Form):
                 "class"
             ] = "chart-input select_box_multiple_series"
 
-        if len(stats.allowed_type_operation_field_name) > 1:
+        # the field is nullable and has no default, unlike the other allowed_* ones
+        if len(stats.allowed_type_operation_field_name or []) > 1:
             self.fields["select_box_operation"] = forms.ChoiceField(
                 choices=stats.allowed_type_operation_field_name_choices(),
                 label="Operation",

--- a/admin_tools_stats/modules.py
+++ b/admin_tools_stats/modules.py
@@ -42,7 +42,7 @@ class DashboardChart(modules.DashboardModule):
         super(DashboardChart, self).__init__(*args, **kwargs)
         self.require_chart_jscss = kwargs["require_chart_jscss"]
         # We use this to came around current implementations of Dashboards which are query inefective
-        self.dashboard_stats = stat_dict[self.graph_key]
+        self.dashboard_stats = stat_dict.get(self.graph_key, None)
         self.title = self.get_title(self.graph_key)
 
     def init_with_context(self, context):
@@ -65,11 +65,10 @@ class DashboardChart(modules.DashboardModule):
 
     def get_title(self, graph_key):
         """Returns graph title"""
-        try:
-            return self.dashboard_stats.graph_title
-        except LookupError as e:
-            self.error_message = str(e)
+        if self.dashboard_stats is None:
+            self.error_message = f"chart '{graph_key}' does not exist or is not visible"
             return ""
+        return self.dashboard_stats.graph_title
 
 
 def get_active_graph():

--- a/admin_tools_stats/tests/test_forms.py
+++ b/admin_tools_stats/tests/test_forms.py
@@ -130,3 +130,18 @@ class ChartSettingsFormTests(TestCase):
         ch = ChartSettingsForm(stats)
 
         self.assertNotIn(f"select_box_dynamic_{chart_filter.id}", ch.fields)
+
+    def test_chart_without_allowed_operations(self):
+        """allowed_type_operation_field_name is nullable and has no default"""
+        stats = baker.make(
+            "DashboardStats",
+            model_name="User",
+            model_app_name="auth",
+            date_field_name="date_joined",
+        )
+        self.assertIsNone(stats.allowed_type_operation_field_name)
+
+        ch = ChartSettingsForm(stats)
+
+        self.assertNotIn("select_box_operation", ch.fields)
+        self.assertIn("time_since", ch.fields)

--- a/admin_tools_stats/tests/test_modules.py
+++ b/admin_tools_stats/tests/test_modules.py
@@ -1,0 +1,61 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+from django.contrib.messages import get_messages
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory, TestCase
+from model_bakery import baker
+
+from admin_tools_stats.modules import DashboardChart, get_active_graph
+
+
+class DashboardChartTests(TestCase):
+    def setUp(self):
+        self.stats = baker.make(
+            "DashboardStats",
+            graph_title="User chart",
+            date_field_name="date_joined",
+            model_name="User",
+            model_app_name="auth",
+            graph_key="user_graph",
+        )
+        get_active_graph()
+
+    def make_request(self):
+        request = RequestFactory().get("/admin/")
+        SessionMiddleware(lambda r: None).process_request(request)
+        MessageMiddleware(lambda r: None).process_request(request)
+        return request
+
+    def test_title_of_an_active_chart(self):
+        chart = DashboardChart(graph_key="user_graph", require_chart_jscss=False)
+        self.assertEqual(chart.title, "User chart")
+        self.assertFalse(hasattr(chart, "error_message"))
+
+    def test_missing_chart_is_reported_in_the_admin(self):
+        """A dashboard configured with an unknown graph_key must not break the admin index"""
+        chart = DashboardChart(graph_key="no_such_graph", require_chart_jscss=False)
+
+        self.assertEqual(chart.title, "")
+        request = self.make_request()
+        chart.init_with_context({"request": request})
+
+        messages = [str(m) for m in get_messages(request)]
+        self.assertEqual(
+            messages,
+            [" dashboard: chart 'no_such_graph' does not exist or is not visible"],
+        )
+
+    def test_hidden_chart_is_reported_too(self):
+        """is_visible=False charts are not in the active set either"""
+        self.stats.is_visible = False
+        self.stats.save()
+        get_active_graph()
+
+        chart = DashboardChart(graph_key="user_graph", require_chart_jscss=False)
+
+        self.assertEqual(chart.title, "")
+        self.assertEqual(chart.error_message, "chart 'user_graph' does not exist or is not visible")


### PR DESCRIPTION
Both crashes were found by writing tests for paths that had none, and both are reachable from the admin without doing anything exotic.

## 1. Chart controls of a chart with no allowed operations

```python
if len(stats.allowed_type_operation_field_name) > 1:
```

That field is nullable and — unlike the other `allowed_*` fields — **has no default**, so a `DashboardStats` created without it (a fixture, a data migration, any code that does not set every field) holds `None`:

```
TypeError: object of type 'NoneType' has no len()
```

Rendering the chart controls fails, so the chart shows an error instead of data.

## 2. A dashboard module for a chart that is gone

```python
self.dashboard_stats = stat_dict[self.graph_key]
```

A dashboard listing a chart that was deleted, renamed, or set `is_visible=False` raises `KeyError` from `DashboardChart.__init__` — which takes down **the whole admin index page**, not just that module.

The friendly outcome was already written: `error_message` plus an `init_with_context()` that turns it into an admin message. Nothing could reach it, because the `KeyError` came first and `get_title()` caught `LookupError` around an attribute access that cannot raise one. The lookup now misses softly and the intended message is what the user gets:

> User chart dashboard: chart 'user_graph' does not exist or is not visible

## Tests

Both paths are covered, and both tests fail with the original `TypeError`/`KeyError` when the fix is reverted — I checked that rather than assuming it. This also covers `modules.py` 55/70-72, which #102 deliberately left alone as unreachable.

113 tests green on SQLite and PostgreSQL; flake8/isort/mypy clean.
