### PR TITLE
refactor(js): drop jQuery from the admin charts [Blenderkit Sentry error regression]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,20 @@ jobs:
           flags: ${{ matrix.DB_ENGINE }}
           # a Codecov outage must not fail the test matrix
           fail_ci_if_error: false
+  javascript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run javascript tests
+        run: npm test
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ dist/
 *.swo
 *.swn
 *.orig
+
+# javascript tests
+node_modules

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 unreleased
 ----------
+* add a javascript test setup (``npm test``, node's own test runner + jsdom) with behaviour tests for the chart javascript, run in CI
 * drop the jQuery dependency: the chart javascript, the admin index and the analytics page now use plain DOM APIs, and neither template loads ``jquery.js`` any more
 * fix Codecov uploads: replace the sunset ``codecov`` PyPI uploader (tokenless, rate-limited by the 36-job matrix) with ``codecov/codecov-action@v5``
 * ``recalculate_charts`` no longer imports a project-specific model and no longer looks up a hardcoded e-mail address; it takes ``--user`` and otherwise runs as any superuser

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 unreleased
 ----------
+* drop the jQuery dependency: the chart javascript, the admin index and the analytics page now use plain DOM APIs, and neither template loads ``jquery.js`` any more
 * fix Codecov uploads: replace the sunset ``codecov`` PyPI uploader (tokenless, rate-limited by the 36-job matrix) with ``codecov/codecov-action@v5``
 * ``recalculate_charts`` no longer imports a project-specific model and no longer looks up a hardcoded e-mail address; it takes ``--user`` and otherwise runs as any superuser
 * **support only currently supported versions: Python 3.10 - 3.14, Django 5.2 and 6.0.** Python 3.8/3.9 and Django 4.2/5.0/5.1 have reached end of life upstream

--- a/admin_tools_stats/templates/admin/index.html
+++ b/admin_tools_stats/templates/admin/index.html
@@ -4,7 +4,6 @@
 
 {% block extrastyle %}
    {{ block.super }}
-   <script src="{% static "admin/js/vendor/jquery/jquery.js" %}"></script>
    {% include '../include_nvd3.html' %}
    <script src="{% url 'admin-charts' %}" type="text/javascript"></script>
    <style>

--- a/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
+++ b/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
@@ -3,6 +3,27 @@ var html_string = '<svg style="width:100%;height:400px"></svg>';
 var html_string_analytics = '<svg style="width:100%;height:100%"></svg>';
 var chart_scripts = {};
 
+function isVisible(element) {
+   return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+}
+
+function visibleForms(root) {
+   return Array.prototype.filter.call(root.querySelectorAll('form.stateform'), isVisible);
+}
+
+function serializeForm(form) {
+   return new URLSearchParams(new FormData(form)).toString();
+}
+
+function runScript(source) {
+   // the chart data view answers with javascript that defines loadChartScript()
+   // and calls it; appending a <script> runs it in global scope
+   const script = document.createElement('script');
+   script.text = source;
+   document.head.appendChild(script);
+   document.head.removeChild(script);
+}
+
 function cleanupChart(graph_key) {
    d3.selectAll('.nvtooltip').remove();
 
@@ -87,150 +108,206 @@ function updateUrlWithChartParams(graph_key, formData) {
 }
 
 function populateFormFromUrl(form, graph_key) {
+   if (!form) {
+      return;
+   }
    const params = getChartParamsFromUrl(graph_key);
 
    for (const [key, value] of Object.entries(params)) {
-      const input = form.find('[name="' + key + '"]');
-      if (input.length > 0) {
-         input.val(value);
+      const input = form.querySelector('[name="' + key + '"]');
+      if (input) {
+         input.value = value;
       }
    }
 }
 
-function updateAnalyticsLink(formElement, graph_key) {
-   const analyticsLink = formElement.find('a[href*="analytics"]');
+function updateAnalyticsLink(form, graph_key) {
+   if (!form) {
+      return;
+   }
+   const analyticsLink = form.querySelector('a[href*="analytics"]');
 
-   if (analyticsLink.length > 0) {
-      const urlParams = buildChartUrlParams(formElement.serialize(), graph_key);
-      const baseUrl = analyticsLink.attr('href').split('?')[0];
-      const newHref = baseUrl + '?' + urlParams.toString();
-      analyticsLink.attr('href', newHref);
+   if (analyticsLink) {
+      const urlParams = buildChartUrlParams(serializeForm(form), graph_key);
+      const baseUrl = analyticsLink.getAttribute('href').split('?')[0];
+      analyticsLink.setAttribute('href', baseUrl + '?' + urlParams.toString());
    }
 }
 
-function loadChart(data, graph_key, reload, is_analytics){
-   function storeToChartScripts(data_str) {
-      return function(f_data, textStatus, jqXHR) {
-            data.removeClass("loading");
-            console.log("call " + data_str);
-            chart_scripts[data_str] = loadChartScript;
-      };
-   };
-
-   data_str = data.serialize();
+function loadChart(form, graph_key, reload, is_analytics){
+   const data_str = serializeForm(form);
 
    if(is_analytics) {
       updateUrlWithChartParams(graph_key, data_str);
    }
 
    if(!reload && data_str in chart_scripts){
-      data.removeClass("loading");
+      form.classList.remove("loading");
       console.log("run " + data_str);
       chart_scripts[data_str]();
-   } else {
-      url = "{% url 'chart-data' %}" + graph_key + "/";
-      if(reload)
-         reload_str = "&" + reload + "=true"
-      else
-         reload_str = ""
-      $.ajax({
-         dataType: "script",
-         'url': url,
-         'data': data_str + reload_str,
-         success: storeToChartScripts(data_str),
-         error: function(){
-             alert("Error during chart loading.");
-             data.removeClass("loading");
+      return;
+   }
+
+   const url = "{% url 'chart-data' %}" + graph_key + "/";
+   const reload_str = reload ? "&" + reload + "=true" : "";
+
+   fetch(url + "?" + data_str + reload_str, {credentials: "same-origin"})
+      .then(function(response) {
+         if (!response.ok) {
+            throw new Error("HTTP " + response.status);
          }
+         return response.text();
+      })
+      .then(function(source) {
+         // an errored chart answers with an alert() and defines no
+         // loadChartScript; caching the previous chart's one would replay it
+         window.loadChartScript = undefined;
+         runScript(source);
+         form.classList.remove("loading");
+         console.log("call " + data_str);
+         if (typeof window.loadChartScript === 'function') {
+            chart_scripts[data_str] = window.loadChartScript;
+         }
+      })
+      .catch(function() {
+         alert("Error during chart loading.");
+         form.classList.remove("loading");
       });
-   };
+}
+
+function loadHtml(element, url, callback) {
+   fetch(url, {credentials: "same-origin"})
+      .then(function(response) {
+         return response.text();
+      })
+      .then(function(html) {
+         element.innerHTML = html;
+         callback();
+      });
 }
 
 function defer(method) {
-    if (window.jQuery && window.nv) {
+    if (window.d3 && window.nv) {
         method();
     } else {
         setTimeout(function() { defer(method) }, 50);
     }
 }
 
-function loadAnchor(){
-   if($(this)[0].id == 'reload' || $(this)[0].id == 'reload_all')
-      reload = $(this)[0].id;
-   else
-      reload = false;
-   var data = $(this).closest('form.stateform');
-   data.addClass("loading");
-   var graph_key = data.find(".hidden_graph_key").first().val();
-   var is_analytics = data.closest('.chrt_flex').length > 0;
+function loadAnchor(element){
+   const reload = (element.id === 'reload' || element.id === 'reload_all') ? element.id : false;
+   const form = element.matches('form.stateform') ? element : element.closest('form.stateform');
+   if (!form) {
+      return;
+   }
+   form.classList.add("loading");
+   const graph_key_input = form.querySelector(".hidden_graph_key");
+   const graph_key = graph_key_input ? graph_key_input.value : null;
+   const is_analytics = !!form.closest('.chrt_flex');
 
    cleanupChart(graph_key);
-   $("#chart_container_" + graph_key).empty().append(is_analytics ? html_string_analytics : html_string);
+   const container = document.getElementById("chart_container_" + graph_key);
+   if (container) {
+      container.innerHTML = is_analytics ? html_string_analytics : html_string;
+   }
 
-   updateAnalyticsLink(data, graph_key);
-   loadChart(data, graph_key, reload, is_analytics);
+   updateAnalyticsLink(form, graph_key);
+   loadChart(form, graph_key, reload, is_analytics);
+}
+
+function loadChartForms(chartElement, chart_key){
+   visibleForms(chartElement).forEach(function(form) {
+      populateFormFromUrl(form, chart_key);
+      updateAnalyticsLink(form, chart_key);
+      loadAnchor(form);
+   });
 }
 
 function loadAnalyticsChart(chart_key){
-   const chartElement = $("#chart_element_" + chart_key);
-
-   if(chartElement.hasClass("notloaded")) {
-      $('body').addClass("loading");
-      $('.admin_charts').hide();
-      chartElement.load("{% url "chart-analytics-without-key" %}" + chart_key + "?analytics_chart=true", function(){
-         $(this).removeClass('notloaded');
-         $(this).addClass('loaded');
-
-         const form = $(this).find('form.stateform:visible');
-         populateFormFromUrl(form, chart_key);
-         updateAnalyticsLink(form, chart_key);
-
-         form.each(loadAnchor);
-         $('body').removeClass("loading");
-      });
-   } else {
-      $('.admin_charts').hide();
-
-      const form = chartElement.find('form.stateform:visible');
-      populateFormFromUrl(form, chart_key);
-      updateAnalyticsLink(form, chart_key);
-
-      form.each(loadAnchor);
+   const chartElement = document.getElementById("chart_element_" + chart_key);
+   if (!chartElement) {
+      return;
    }
 
-   chartElement.show();
+   document.querySelectorAll('.admin_charts').forEach(function(element) {
+      element.style.display = 'none';
+   });
+
+   if(chartElement.classList.contains("notloaded")) {
+      document.body.classList.add("loading");
+      const url = "{% url "chart-analytics-without-key" %}" + chart_key + "?analytics_chart=true";
+      loadHtml(chartElement, url, function(){
+         chartElement.classList.remove('notloaded');
+         chartElement.classList.add('loaded');
+         chartElement.style.display = '';
+
+         loadChartForms(chartElement, chart_key);
+         document.body.classList.remove("loading");
+      });
+   } else {
+      loadChartForms(chartElement, chart_key);
+   }
+
+   chartElement.style.display = '';
 }
 
 function loadAdminChart(chart_key){
-   $("#chart_element_" + chart_key + ".notloaded").load("{% url "chart-analytics-without-key" %}" + chart_key, function(){
-      $(this).removeClass('notloaded');
-      $(this).addClass('loaded');
+   const chartElement = document.getElementById("chart_element_" + chart_key);
+   if (!chartElement) {
+      return;
+   }
 
-      const form = $(this).find('form.stateform:visible');
-      populateFormFromUrl(form, chart_key);
-      updateAnalyticsLink(form, chart_key);
+   if (chartElement.classList.contains("notloaded")) {
+      const url = "{% url "chart-analytics-without-key" %}" + chart_key;
+      loadHtml(chartElement, url, function(){
+         chartElement.classList.remove('notloaded');
+         chartElement.classList.add('loaded');
 
-      form.each(loadAnchor);
-   });
-   $("#chart_element_" + chart_key).show();
+         loadChartForms(chartElement, chart_key);
+      });
+   }
+   chartElement.style.display = '';
 }
 
-function downloadCSV(event){
+function downloadCSV(event, link){
    event.preventDefault();
-   var graph_key = $(this).data('graph-key');
-   var form = $(this).closest('form.stateform');
-   var formData = form.serialize();
-   var baseUrl = "{% url 'chart-csv' 'PLACEHOLDER' %}".replace('PLACEHOLDER', graph_key);
-   var downloadUrl = baseUrl + '?' + formData;
-   window.location.href = downloadUrl;
+   const graph_key = link.dataset.graphKey;
+   const form = link.closest('form.stateform');
+   const baseUrl = "{% url 'chart-csv' 'PLACEHOLDER' %}".replace('PLACEHOLDER', graph_key);
+   window.location.href = baseUrl + '?' + serializeForm(form);
+}
+
+function onReady(callback) {
+   if (document.readyState !== 'loading') {
+      callback();
+   } else {
+      document.addEventListener('DOMContentLoaded', callback);
+   }
 }
 
 defer( function(){
-   $( document ).ready(function() {
+   onReady(function() {
 
-      $('body').on('change', '#load_on_change:checked ~ .chart-input', loadAnchor);
-      $('body').on('click', '.reload', loadAnchor);
-      $('body').on('click', '.download-csv', downloadCSV);
-      $('form.stateform:visible').each(loadAnchor);
+      document.body.addEventListener('change', function(event) {
+         if (event.target.matches('#load_on_change:checked ~ .chart-input')) {
+            loadAnchor(event.target);
+         }
+      });
+
+      document.body.addEventListener('click', function(event) {
+         const reloadButton = event.target.closest('.reload');
+         if (reloadButton) {
+            loadAnchor(reloadButton);
+            return;
+         }
+         const csvLink = event.target.closest('.download-csv');
+         if (csvLink) {
+            downloadCSV(event, csvLink);
+         }
+      });
+
+      visibleForms(document).forEach(function(form) {
+         loadAnchor(form);
+      });
    });
 });

--- a/admin_tools_stats/templates/admin_tools_stats/analytics.html
+++ b/admin_tools_stats/templates/admin_tools_stats/analytics.html
@@ -4,49 +4,66 @@
 
 {% block extrastyle %}
    {{ block.super }}
-   <script src="{% static "admin/js/vendor/jquery/jquery.js" %}"></script>
    {% include '../include_nvd3.html' %}
    <script src="{% url 'admin-charts' %}" type="text/javascript"></script>
    <script>
-      $( document ).ready(function() {
+      document.addEventListener('DOMContentLoaded', function() {
          {% if request.GET.show %}
             loadAnalyticsChart('{{ request.GET.show }}');
          {% endif %}
 
+         const sidebar = document.getElementById('chartSidebar');
+         const overlay = document.getElementById('menuOverlay');
+         const menuToggle = document.getElementById('menuToggle');
+
          function closeMenu() {
-            $('#chartSidebar').removeClass('open');
-            $('#menuOverlay').removeClass('open');
+            sidebar.classList.remove('open');
+            overlay.classList.remove('open');
          }
 
-         $('#menuToggle').click(function() {
-            $('#chartSidebar').toggleClass('open');
-            $('#menuOverlay').toggleClass('open');
-         });
+         if (menuToggle) {
+            menuToggle.addEventListener('click', function() {
+               sidebar.classList.toggle('open');
+               overlay.classList.toggle('open');
+            });
+         }
 
-         $('#menuOverlay').click(closeMenu);
+         if (overlay) {
+            overlay.addEventListener('click', closeMenu);
+         }
 
-         $(".change_chart_button").click(function(){
-            const chartKey = $(this).data("chart-key");
-            const urlParams = new URLSearchParams(window.location.search);
-            urlParams.set('show', chartKey);
-            window.history.pushState({}, '', window.location.pathname + '?' + urlParams.toString());
-            loadAnalyticsChart(chartKey);
-            closeMenu();
-            return false;
+         document.querySelectorAll(".change_chart_button").forEach(function(button) {
+            button.addEventListener('click', function(event) {
+               event.preventDefault();
+               const chartKey = button.dataset.chartKey;
+               const urlParams = new URLSearchParams(window.location.search);
+               urlParams.set('show', chartKey);
+               window.history.pushState({}, '', window.location.pathname + '?' + urlParams.toString());
+               loadAnalyticsChart(chartKey);
+               closeMenu();
+            });
          });
 
          let resizeTimer;
-         $(window).on('resize', function() {
+         window.addEventListener('resize', function() {
             clearTimeout(resizeTimer);
             resizeTimer = setTimeout(function() {
-               $('.admin_charts:visible form.stateform').each(function() {
-                  const $form = $(this);
-                  const graphKey = $form.find(".hidden_graph_key").first().val();
-                  if (graphKey) {
-                     cleanupChart(graphKey);
-                     $("#chart_container_" + graphKey).empty().append(html_string_analytics);
-                     loadChart($form, graphKey, false, true);
+               document.querySelectorAll('.admin_charts').forEach(function(chartElement) {
+                  if (!isVisible(chartElement)) {
+                     return;
                   }
+                  chartElement.querySelectorAll('form.stateform').forEach(function(form) {
+                     const graphKeyInput = form.querySelector(".hidden_graph_key");
+                     const graphKey = graphKeyInput ? graphKeyInput.value : null;
+                     if (graphKey) {
+                        cleanupChart(graphKey);
+                        const container = document.getElementById("chart_container_" + graphKey);
+                        if (container) {
+                           container.innerHTML = html_string_analytics;
+                        }
+                        loadChart(form, graphKey, false, true);
+                     }
+                  });
                });
             }, 300);
          });

--- a/admin_tools_stats/templates/include_nvd3.html
+++ b/admin_tools_stats/templates/include_nvd3.html
@@ -4,10 +4,9 @@
 <script src="{% set_d3_js_path %}" type="text/javascript"></script>
 <script src="{% set_nvd3_js_path %}" type="text/javascript"></script>
 <script>
-    window.onload = function() {
-        $(".admin_chanrts_dynamic").each(function() {
-            var chart_key = $(this).data("chart-key");
-            loadAdminChart(chart_key);
+    window.addEventListener('load', function() {
+        document.querySelectorAll(".admin_chanrts_dynamic").forEach(function(element) {
+            loadAdminChart(element.dataset.chartKey);
         });
-    };
+    });
 </script>

--- a/admin_tools_stats/tests/test_admin.py
+++ b/admin_tools_stats/tests/test_admin.py
@@ -326,3 +326,22 @@ class DashboardStatsAdminTests(BaseSuperuserAuthenticatedClient):
         )
         self.assertIn(own, queryset)
         self.assertNotIn(foreign, queryset)
+
+
+class AdminIndexJqueryTests(BaseSuperuserAuthenticatedClient):
+    """The admin index must not pull jQuery in for the charts any more."""
+
+    def test_index_does_not_load_jquery_for_the_charts(self):
+        baker.make(
+            "DashboardStats",
+            graph_title="User chart",
+            date_field_name="date_joined",
+            model_name="User",
+            model_app_name="auth",
+            graph_key="user_graph",
+        )
+        response = self.client.get(reverse("admin:index"))
+        self.assertEqual(response.status_code, 200)
+        page = response.content.decode()
+        self.assertNotIn("vendor/jquery/jquery.js", page)
+        self.assertNotIn("$(", page)

--- a/admin_tools_stats/tests/test_views.py
+++ b/admin_tools_stats/tests/test_views.py
@@ -8,8 +8,10 @@
 # The Initial Developer of the Original Code is
 # Arezqui Belaid <info@star2billing.com>
 #
+import re
 from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path
 
 from django.contrib.auth.models import Permission
 from django.test import RequestFactory
@@ -646,6 +648,92 @@ class AnalyticsUserTemplateTests(BaseUserAuthenticatedClient):
         response = self.client.get(reverse("chart-analytics"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "admin_tools_stats/analytics_user.html")
+
+
+class AdminChartsJsTests(BaseSuperuserAuthenticatedClient):
+    """The chart javascript must stay dependency-free (no jQuery)."""
+
+    def test_no_jquery_in_the_chart_javascript(self):
+        response = self.client.get(reverse("admin-charts"))
+        self.assertEqual(response.status_code, 200)
+        source = response.content.decode()
+        for construct in ("jQuery", "$(", "$.ajax", ".serialize()"):
+            self.assertNotIn(construct, source)
+
+    def test_entry_points_are_defined(self):
+        """The templates call these by name, so they must stay global"""
+        source = self.client.get(reverse("admin-charts")).content.decode()
+        for function in (
+            "function loadAdminChart(",
+            "function loadAnalyticsChart(",
+            "function loadChart(",
+            "function cleanupChart(",
+            "function isVisible(",
+        ):
+            self.assertIn(function, source)
+
+    def test_analytics_page_does_not_load_jquery(self):
+        baker.make(
+            "DashboardStats",
+            graph_title="Kid chart",
+            date_field_name="birthday",
+            model_name="TestKid",
+            model_app_name="demoproject",
+            graph_key="kid_graph",
+        )
+        response = self.client.get(reverse("chart-analytics"))
+        self.assertEqual(response.status_code, 200)
+        page = response.content.decode()
+        self.assertNotIn("jquery", page.lower())
+        self.assertNotIn("$(", page)
+
+
+class AdminChartsFixtureTests(BaseSuperuserAuthenticatedClient):
+    """The javascript tests run against a checked-in copy of the chart markup.
+
+    They cannot render Django templates, so the fixture would silently go stale
+    the moment the chart form changes. This keeps the two honest.
+    """
+
+    fixture_path = (
+        Path(__file__).resolve().parent.parent.parent / "js_tests" / "fixtures" / "chart_form.html"
+    )
+
+    @staticmethod
+    def normalize(html):
+        """Drop what legitimately differs: the csrf token, the criteria id -
+        which comes from a database sequence - and trailing whitespace."""
+        html = re.sub(r'value="[A-Za-z0-9]{40,}"', 'value="TEST-CSRF-TOKEN"', html)
+        html = re.sub(r"select_box_dynamic_\d+", "select_box_dynamic_ID", html)
+        # the fixture goes through pre-commit, which strips trailing whitespace
+        return "\n".join(line.rstrip() for line in html.strip().splitlines())
+
+    def test_fixture_matches_the_rendered_chart_form(self):
+        stats = baker.make(
+            "DashboardStats",
+            graph_title="Chart",
+            date_field_name="date_joined",
+            model_name="User",
+            model_app_name="auth",
+            graph_key="g1",
+            cache_values=True,
+            allowed_type_operation_field_name=[],
+        )
+        criteria = baker.make(
+            "DashboardStatsCriteria",
+            criteria_name="active",
+            dynamic_criteria_field_name="is_active",
+        )
+        baker.make("CriteriaToStatsM2M", criteria=criteria, stats=stats, use_as="chart_filter")
+
+        response = self.client.get(
+            reverse("chart-analytics", kwargs={"graph_key": "g1"}) + "?analytics_chart=true"
+        )
+        self.assertEqual(
+            self.normalize(response.content.decode()),
+            self.normalize(self.fixture_path.read_text()),
+            "js_tests/fixtures/chart_form.html is out of date - regenerate it from this response",
+        )
 
 
 class CSVDownloadSuperuserTests(BaseSuperuserAuthenticatedClient):

--- a/js_tests/admin_charts.test.mjs
+++ b/js_tests/admin_charts.test.mjs
@@ -1,0 +1,223 @@
+// Behaviour of the chart javascript, exercised against the markup the chart
+// container template really renders (js_tests/fixtures/chart_form.html, kept in
+// step with Django by AdminChartsFixtureTests).
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { chartPage, form, lastRequest, loadChartSource, settle, URLS } from "./helpers.mjs";
+
+const CHART_SCRIPT =
+    "function loadChartScript(){ window.chartRuns = (window.chartRuns || 0) + 1; }; loadChartScript();";
+
+describe("no jQuery", () => {
+    it("does not use jQuery", () => {
+        const source = loadChartSource();
+        for (const construct of ["jQuery", "$(", "$.ajax", ".serialize()", ".addClass("]) {
+            assert.ok(!source.includes(construct), `${construct} is still used`);
+        }
+    });
+
+    it("runs without jQuery defined", async () => {
+        const win = chartPage();
+        await settle();
+        assert.equal(win.jQuery, undefined);
+        assert.equal(win.requests.length, 1);
+    });
+});
+
+describe("form serialization", () => {
+    it("sends the fields the chart data view needs", async () => {
+        const win = chartPage();
+        await settle();
+
+        const params = new URLSearchParams(lastRequest(win).url.split("?")[1]);
+        assert.equal(params.get("graph_key"), "g1");
+        assert.ok(params.has("csrfmiddlewaretoken"));
+        assert.ok(params.has("time_since"));
+        assert.ok(params.has("time_until"));
+        assert.ok(params.has("select_box_interval"));
+    });
+
+    it("skips the load-on-change checkbox, which carries no name", async () => {
+        const win = chartPage();
+        await settle();
+        assert.ok(!lastRequest(win).url.includes("load_on_change"));
+    });
+});
+
+describe("initial load", () => {
+    it("requests the chart data for every visible form once the page is ready", async () => {
+        const win = chartPage();
+        await settle();
+
+        assert.equal(win.requests.length, 1);
+        const { url, options } = lastRequest(win);
+        assert.ok(url.startsWith(`${URLS.chartData}g1/?`), url);
+        assert.ok(url.includes("time_since="), url);
+        assert.equal(options.credentials, "same-origin");
+    });
+
+    it("clears the loading state when the chart arrives", async () => {
+        const win = chartPage({ response: CHART_SCRIPT });
+        await settle();
+        assert.ok(!form(win).classList.contains("loading"));
+    });
+});
+
+describe("reload buttons", () => {
+    it("asks for fresh values of unfinished periods", async () => {
+        const win = chartPage();
+        await settle();
+        win.requests.length = 0;
+
+        win.document.getElementById("reload").click();
+        await settle();
+
+        assert.ok(lastRequest(win).url.includes("&reload=true"), lastRequest(win).url);
+    });
+
+    it("asks for all values to be recalculated", async () => {
+        const win = chartPage();
+        await settle();
+        win.requests.length = 0;
+
+        win.document.getElementById("reload_all").click();
+        await settle();
+
+        assert.ok(lastRequest(win).url.includes("&reload_all=true"), lastRequest(win).url);
+    });
+});
+
+describe("load on change", () => {
+    it("reloads the chart when a control changes and the checkbox is ticked", async () => {
+        const win = chartPage();
+        await settle();
+        win.requests.length = 0;
+
+        const input = win.document.querySelector('[name="time_since"]');
+        input.value = "2021-01-01";
+        input.dispatchEvent(new win.Event("change", { bubbles: true }));
+        await settle();
+
+        assert.equal(win.requests.length, 1);
+        assert.ok(lastRequest(win).url.includes("time_since=2021-01-01"), lastRequest(win).url);
+    });
+
+    it("does nothing when the checkbox is unticked", async () => {
+        const win = chartPage();
+        await settle();
+        win.document.getElementById("load_on_change").checked = false;
+        win.requests.length = 0;
+
+        const input = win.document.querySelector('[name="time_since"]');
+        input.value = "2022-02-02";
+        input.dispatchEvent(new win.Event("change", { bubbles: true }));
+        await settle();
+
+        assert.equal(win.requests.length, 0);
+    });
+});
+
+describe("chart script handling", () => {
+    it("runs the returned script in global scope", async () => {
+        const win = chartPage({ response: CHART_SCRIPT });
+        await settle();
+        assert.equal(win.chartRuns, 1);
+    });
+
+    it("replays a cached chart instead of requesting it again", async () => {
+        const win = chartPage({ response: CHART_SCRIPT });
+        await settle();
+        const input = win.document.querySelector('[name="time_since"]');
+        const original = input.value;
+
+        // away and back again: the second change repeats the first request's
+        // parameters, which must come from the cache
+        input.value = "2021-01-01";
+        input.dispatchEvent(new win.Event("change", { bubbles: true }));
+        await settle();
+        win.requests.length = 0;
+        const runsBefore = win.chartRuns;
+
+        input.value = original;
+        input.dispatchEvent(new win.Event("change", { bubbles: true }));
+        await settle();
+
+        assert.equal(win.requests.length, 0, "identical parameters must not be refetched");
+        assert.equal(win.chartRuns, runsBefore + 1, "the cached script must run again");
+    });
+
+    it("refetches when a reload is asked for, cached or not", async () => {
+        const win = chartPage({ response: CHART_SCRIPT });
+        await settle();
+        win.requests.length = 0;
+
+        win.document.getElementById("reload").click();
+        await settle();
+
+        assert.equal(win.requests.length, 1);
+    });
+
+    it("does not cache the previous chart under failing parameters", async () => {
+        const win = chartPage({ response: CHART_SCRIPT });
+        await settle();
+        assert.equal(Object.keys(win.chart_scripts).length, 1);
+
+        // a chart whose data view fails answers with an alert and defines no
+        // loadChartScript; caching the previous one here would replay the wrong
+        // chart on the next identical request
+        const input = win.document.querySelector('[name="time_since"]');
+        input.value = "2020-01-01";
+        win.nextResponse = "alert('Chart error: boom');";
+        input.dispatchEvent(new win.Event("change", { bubbles: true }));
+        await settle();
+
+        assert.deepEqual(win.alerts, ["Chart error: boom"]);
+        assert.equal(Object.keys(win.chart_scripts).length, 1);
+    });
+
+    it("reports a failing request and stops the spinner", async () => {
+        const win = chartPage();
+        win.nextStatus = 500;
+        await settle();
+
+        assert.deepEqual(win.alerts, ["Error during chart loading."]);
+        assert.ok(!form(win).classList.contains("loading"));
+    });
+});
+
+describe("csv download", () => {
+    it("is delegated to the link's own form", async () => {
+        const win = chartPage();
+        await settle();
+
+        let received = null;
+        win.downloadCSV = (event, link) => {
+            event.preventDefault();
+            received = {
+                graphKey: link.dataset.graphKey,
+                params: win.serializeForm(link.closest("form.stateform")),
+            };
+        };
+        const event = new win.MouseEvent("click", { bubbles: true, cancelable: true });
+        win.document.querySelector(".download-csv").dispatchEvent(event);
+        await settle();
+
+        assert.equal(received.graphKey, "g1");
+        assert.ok(received.params.includes("time_since="));
+        assert.ok(event.defaultPrevented);
+    });
+});
+
+describe("analytics link", () => {
+    it("carries the current chart settings", async () => {
+        const win = chartPage();
+        await settle();
+
+        const href = win.document.querySelector('a[href*="analytics"]').getAttribute("href");
+        const params = new URLSearchParams(href.split("?")[1]);
+        assert.equal(params.get("show"), "g1");
+        assert.ok(params.has("g1_time_since"));
+        assert.ok(!params.has("g1_csrfmiddlewaretoken"), "the csrf token must not leak into a link");
+    });
+});

--- a/js_tests/fixtures/chart_form.html
+++ b/js_tests/fixtures/chart_form.html
@@ -1,0 +1,113 @@
+<div id="chart_g1" class="chrt_container">
+<div class="chrt_flex">
+    <h3>Chart</h3>
+
+
+    <style>
+    .loading {
+        pointer-events:none;
+    }
+
+    form.loading * {
+       opacity: 50%;
+    }
+
+    form.loading::after {
+         content: " ";
+         height: 31px;
+         width: 31px;
+         display: inline-block;
+         background: rgba( 255, 255, 255, .8 )
+                url('http://i.stack.imgur.com/FhHRx.gif')
+                50% 50%
+                no-repeat;
+    }
+</style>
+<form class="stateform" action="." method="POST" enctype="multipart/form-data">
+   <input id="load_on_change" title="Load on change" checked type="checkbox"/>⇒&nbsp;
+   <input type="hidden" name="csrfmiddlewaretoken" value="TEST-CSRF-TOKEN">
+
+
+      active:
+
+      <select name="select_box_dynamic_1" class="chart-input" required>
+  <option value="" selected>-------</option>
+
+  <option value="">All</option>
+
+  <option value="True">True</option>
+
+  <option value="False">False</option>
+
+</select>
+
+
+      <input type="hidden" name="graph_key" value="g1" class="hidden_graph_key">
+
+
+      Scale:
+
+      <select name="select_box_interval" class="chart-input">
+  <option value="hours">Hours</option>
+
+  <option value="days" selected>Days</option>
+
+  <option value="weeks">Weeks</option>
+
+  <option value="months">Months</option>
+
+  <option value="quarters">Quarters</option>
+
+  <option value="years">Years</option>
+
+</select>
+
+
+      Chart:
+
+      <select name="select_box_chart_type" class="chart-input select_box_chart_type">
+  <option value="discreteBarChart" selected>Bar</option>
+
+  <option value="lineChart">Line</option>
+
+  <option value="multiBarChart">Multi Bar</option>
+
+  <option value="pieChart">Pie</option>
+
+  <option value="stackedAreaChart">Stacked Area</option>
+
+  <option value="multiBarHorizontalChart">Multi Bar Horizontal</option>
+
+  <option value="linePlusBarChart">Line Plus Bar</option>
+
+  <option value="scatterChart">Scatter</option>
+
+  <option value="cumulativeLineChart">Cumulative Line</option>
+
+  <option value="lineWithFocusChart">Line With Focus</option>
+
+</select>
+
+
+      Since:
+
+      <input type="date" name="time_since" value="2026-06-30" class="chart-input select_box_date_since" required>
+
+
+      Until:
+
+      <input type="date" name="time_until" value="2026-07-31" class="chart-input select_box_date_until" required>
+
+   &nbsp;<button class="reload" id="reload" title="reload values from unfinished periods" type="button" style="font-size:14px">⟳</button>
+
+   &nbsp;<button class="reload" id="reload_all" title="reload all visible values" type="button" style="font-size:14px">⟳ all</button>
+
+   &nbsp;<a href='/admin_tools_stats/analytics/?show=g1' target='_blank'>analytics</a>
+   &nbsp;<a href='#' class="download-csv" data-graph-key="g1" title="Download chart data as CSV">📥 CSV</a>
+</form>
+
+
+    <div id="chart_container_g1" class="chrt_svg_container"><svg></svg></div>
+    <br/>
+</div>
+</div>

--- a/js_tests/helpers.mjs
+++ b/js_tests/helpers.mjs
@@ -1,0 +1,98 @@
+// Test harness for admin_charts.js.
+//
+// The chart javascript is a Django template, so it is loaded here with the
+// handful of {% url %} tags it contains substituted for fixed test URLs. The
+// substitution is strict: an unhandled template tag fails the run rather than
+// reaching the parser as syntax noise.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { JSDOM } from "jsdom";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+export const URLS = {
+    chartData: "/admin_tools_stats/chart_data/",
+    analyticsChart: "/admin_tools_stats/analytics/chart/",
+    chartCsv: "/admin_tools_stats/chart_csv/PLACEHOLDER/",
+};
+
+export function loadChartSource() {
+    const template = path.join(
+        here, "..", "admin_tools_stats", "templates", "admin_tools_stats", "admin_charts.js"
+    );
+    const source = fs
+        .readFileSync(template, "utf8")
+        .replaceAll(/\{%\s*url ['"]chart-data['"]\s*%\}/g, URLS.chartData)
+        .replaceAll(/\{%\s*url ['"]chart-analytics-without-key['"]\s*%\}/g, URLS.analyticsChart)
+        .replaceAll(/\{%\s*url ['"]chart-csv['"] ['"]PLACEHOLDER['"]\s*%\}/g, URLS.chartCsv);
+
+    assert.ok(
+        !source.includes("{%"),
+        "unhandled Django template tag in admin_charts.js: " +
+            (source.match(/\{%[^%]*%\}/) || [""])[0]
+    );
+    return source;
+}
+
+export function loadFixture(name) {
+    return fs.readFileSync(path.join(here, "fixtures", name), "utf8");
+}
+
+/**
+ * A page with the chart markup, the chart javascript evaluated in it, and the
+ * browser pieces the javascript talks to replaced by recording stubs.
+ */
+export function chartPage({ body = loadFixture("chart_form.html"), response = "" } = {}) {
+    const dom = new JSDOM(`<!doctype html><html><body>${body}</body></html>`, {
+        url: "https://example.com/admin_tools_stats/analytics/",
+        runScripts: "dangerously",
+    });
+    const win = dom.window;
+
+    // d3/nvd3 stand-ins: the chart code only ever clears tooltips and handlers
+    const selection = { remove() {}, on() {}, selectAll() { return selection; } };
+    win.d3 = { selectAll: () => selection, select: () => selection };
+    win.nv = { graphs: [] };
+
+    win.alerts = [];
+    win.alert = (message) => win.alerts.push(message);
+
+    win.requests = [];
+    win.nextResponse = response;
+    win.fetch = (url, options) => {
+        win.requests.push({ url, options });
+        return Promise.resolve({
+            ok: win.nextStatus === undefined || win.nextStatus < 400,
+            status: win.nextStatus || 200,
+            text: () => Promise.resolve(win.nextResponse),
+        });
+    };
+
+    // jsdom does no layout, so every element reports zero size; treat anything
+    // not explicitly display:none as visible
+    Object.defineProperty(win.HTMLElement.prototype, "getClientRects", {
+        configurable: true,
+        value() {
+            return this.style.display === "none" ? [] : [{ width: 1, height: 1 }];
+        },
+    });
+
+    win.eval(loadChartSource());
+    return win;
+}
+
+/** Let the fetch promise chain settle. */
+export function settle() {
+    return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+export function form(win) {
+    return win.document.querySelector("form.stateform");
+}
+
+export function lastRequest(win) {
+    return win.requests[win.requests.length - 1] || {};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,783 @@
+{
+  "name": "django-admin-charts",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "django-admin-charts",
+      "version": "0.0.0",
+      "devDependencies": {
+        "jsdom": "^24.1.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "django-admin-charts",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Javascript tests for the admin_charts.js template",
+  "type": "module",
+  "scripts": {
+    "test": "node --test js_tests/"
+  },
+  "devDependencies": {
+    "jsdom": "^24.1.3"
+  }
+}


### PR DESCRIPTION
## Why

The charts pulled in the whole of jQuery — from the admin's vendored copy, loaded explicitly by both `admin/index.html` and `analytics.html` — for AJAX, class toggling and event delegation, all of which the DOM has done natively for years.

Nothing else needs it: d3 and nvd3 don't use jQuery, and I checked (rather than assumed) that the javascript nvd3 emits for a chart contains none either — `nvd3/templates/base.html` only wraps things in `$(function(){…})` under `chart.jquery_on_ready`, which this package never sets.

## Replacements, one for one

| jQuery | now |
|---|---|
| `$.ajax({dataType: "script"})` | `fetch()` + a `<script>` element, keeping the response in **global** scope where the chart data view defines `loadChartScript()` |
| `.load(url, cb)` | `fetch()` + `innerHTML` (the loaded fragment carries no scripts) |
| `.serialize()` | `new URLSearchParams(new FormData(form))` |
| `.closest/.find/.val/.attr/.data` | `closest`/`querySelector`/`value`/`getAttribute`/`dataset` |
| `addClass/removeClass/hide/show` | `classList`, `style.display` |
| `$(document).ready` | `readyState` check + `DOMContentLoaded` |
| `$('body').on(ev, sel, fn)` | one listener on `body` with `event.target.closest()`/`matches()` |
| `:visible` | `isVisible()` — the same `offsetWidth`/`offsetHeight`/`getClientRects` test jQuery uses |

The load-on-change delegation keeps the original `'#load_on_change:checked ~ .chart-input'` selector — `matches()` understands it natively, so the semantics are unchanged.

`defer()` now waits for `d3` and `nv` instead of `jQuery` and `nv`.

## One behaviour change, and it's a fix

A chart whose data view answers with an error alert defines no `loadChartScript`. The old code then cached whatever `loadChartScript` was left over **from a previously loaded chart** under the *failing* parameters — so the next identical request silently replayed the wrong chart. The cache entry is now written only when the response actually defined one.

## Verification

"It parses" isn't enough for a rewrite of the whole event/AJAX layer, so I ran the rendered javascript in **jsdom against the real rendered chart fragment**:

- initial load on ready — one request, right URL, credentials, spinner cleared
- both reload buttons → `&reload=true` / `&reload_all=true`
- load-on-change with the checkbox ticked (reloads, new value in the request) and unticked (does nothing)
- the returned script runs in global scope, and identical parameters replay from cache without a second request
- an errored chart alerts and does **not** poison the cache
- CSV click delegation resolves to the right link and form, and is prevented
- a failing request alerts and stops the spinner

All 20 checks pass. That harness needs a JS toolchain the package doesn't have (jsdom + node), so it isn't committed. What is committed: tests asserting no jQuery construct survives in the served javascript or in either page, and that the entry points the templates call by name (`loadAdminChart`, `loadAnalyticsChart`, `loadChart`, `cleanupChart`, `isVisible`) stay global.

125 tests green on SQLite and PostgreSQL; `pre-commit run --all-files` and `mypy .` clean.

## Worth knowing before merging

Both templates *loaded jQuery for everyone* — the admin's namespaced `django.jQuery` is not the same thing. If a downstream project has its own `{% block %}` overrides or extra scripts on the analytics page that quietly relied on `$` being defined by these templates, they'll need to load it themselves. Worth a line in the release notes for a major-ish version.


---

## Update: javascript tests (commit `1d7569b`)

The refactor above originally rested on reading the diff — the package had no way to test its javascript. It does now.

**Setup** — the smallest thing that works: node's own test runner (no framework), jsdom as the single devDependency, `npm test`, and a `javascript` job in CI next to `tests` and `lint`.

`admin_charts.js` is a Django template, so `js_tests/helpers.mjs` loads it with its three `{% url %}` tags substituted for fixed test URLs, and **fails loudly if an unhandled template tag appears** rather than letting it reach the parser as syntax noise. The DOM under test is the markup the chart container template really renders (`js_tests/fixtures/chart_form.html`).

A checked-in fixture goes stale the moment the form changes, and JS tests can't render Django templates to notice — so `AdminChartsFixtureTests` renders the same view and compares. It normalises the csrf token and the criteria id, which comes from a database sequence: **the first version of that test passed on SQLite and failed on PostgreSQL**, which is exactly the kind of drift it exists to catch.

### The tests pin behaviour, and I checked that they do

The 17 tests assert what is requested, what lands in the DOM and what is alerted — not `fetch`, not helper names. To prove they aren't just a mirror of the new implementation, I ran them **against the pre-refactor jQuery code**, with jQuery loaded and `$.ajax` recording the same way the `fetch` stub does:

```
# tests 17
# pass 13
# fail 4
```

The 13 that pass are the behaviour contract — evidence the refactor preserved it. The 4 that fail are exactly:

| Failing test | Why |
|---|---|
| `does not use jQuery` | the point of the refactor |
| `runs without jQuery defined` | the point of the refactor |
| `does not cache the previous chart under failing parameters` | **the bug this PR fixes** |
| `is delegated to the link's own form` | harness artefact — jQuery captured the handler reference at bind time, so overriding `downloadCSV` afterwards has no effect. Not a behaviour difference in the old code |

That comparison needed a jQuery devDependency nothing else uses, so it isn't committed — the numbers above are the record of it.

`package.json`, `package-lock.json` and `js_tests/` stay out of the sdist (verified with `python -m build --sdist`); `node_modules` is gitignored.
