### PR TITLE
test: cover the last uncovered branches [Blenderkit Sentry error regression]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 unreleased
 ----------
+* reach full statement and branch coverage; ``get_series_query_parameters()`` no longer has a path that leaves ``single_value`` unbound
 * add a javascript test setup (``npm test``, node's own test runner + jsdom) with behaviour tests for the chart javascript, run in CI
 * drop the jQuery dependency: the chart javascript, the admin index and the analytics page now use plain DOM APIs, and neither template loads ``jquery.js`` any more
 * fix Codecov uploads: replace the sunset ``codecov`` PyPI uploader (tokenless, rate-limited by the 36-job matrix) with ``codecov/codecov-action@v5``

--- a/admin_tools_stats/models.py
+++ b/admin_tools_stats/models.py
@@ -578,13 +578,13 @@ class DashboardStats(models.Model):
                     dynamic_values = dynamic_criteria[dynamic_key]
                     dynamic_field_name = m2m.get_dynamic_criteria_field_name()
                     criteria_key = "id" if dynamic_field_name == "" else dynamic_field_name
-                    if isinstance(dynamic_values, (list, tuple)):
-                        single_value = False
-                    elif isinstance(dynamic_values, str):
+                    if isinstance(dynamic_values, str):
                         dynamic_values = [
                             dynamic_values,
                         ]
                         single_value = True
+                    else:
+                        single_value = False
 
                     for dynamic_value in dynamic_values:
                         try:
@@ -741,8 +741,7 @@ class DashboardStats(models.Model):
         )
         for tv in serie_map:
             time = tv[0]
-            if time not in series:
-                series[time] = {}
+            series[time] = {}
             i = 0
             for name in names:
                 i += 1

--- a/admin_tools_stats/tests/test_models.py
+++ b/admin_tools_stats/tests/test_models.py
@@ -1747,6 +1747,91 @@ class PytzTimezoneTests(TestCase):
             self.assertEqual(key.tzinfo, zoneinfo.ZoneInfo("Europe/Prague"))
 
 
+class CachedValueTimezoneTests(TestCase):
+    """Cached dates are naive when USE_TZ is off and aware when it is on."""
+
+    def setUp(self):
+        self.stats = baker.make(
+            "DashboardStats",
+            date_field_name="date_joined",
+            model_name="User",
+            model_app_name="auth",
+            graph_key="user_graph",
+            cache_values=True,
+            type_operation_field_name="Count",
+            operation_field_name="id",
+        )
+        self.user = baker.make("User", is_superuser=True)
+
+    def cached_series(self, date, since, until):
+        baker.make(
+            "CachedValue",
+            stats=self.stats,
+            time_scale="days",
+            operation="Count",
+            operation_field_name="id",
+            dynamic_choices=[],
+            filtered_value="",
+            date=date,
+            value=3,
+        )
+        return self.stats.get_multi_time_series_cached(
+            {},
+            since,
+            until,
+            Interval.days,
+            "Count",
+            "id",
+            self.user,
+        )
+
+    @skipIf(
+        settings.DATABASES["default"]["ENGINE"] == "django.db.backends.mysql",
+        "no support of USE_TZ=False in mysql",
+    )
+    @override_settings(USE_TZ=False)
+    def test_naive_cached_dates_are_used_as_they_are(self):
+        serie = self.cached_series(
+            datetime(2010, 10, 10), datetime(2010, 10, 9), datetime(2010, 10, 11)
+        )
+        self.assertEqual(serie[datetime(2010, 10, 10)][""], 3)
+
+    @override_settings(USE_TZ=True, TIME_ZONE="Europe/Prague")
+    def test_aware_cached_dates_are_converted_to_the_chart_timezone(self):
+        serie = self.cached_series(
+            datetime(2010, 10, 9, 22, tzinfo=timezone.utc),
+            datetime(2010, 10, 9, tzinfo=timezone.utc),
+            datetime(2010, 10, 11, tzinfo=timezone.utc),
+        )
+        prague = zoneinfo.ZoneInfo("Europe/Prague")
+        self.assertEqual(list(serie)[0].tzinfo, prague)
+
+
+class OperationsListCleanTests(TestCase):
+    """clean() validates each operation field, and tolerates blank entries."""
+
+    def make_stats(self, operation_field_name):
+        return baker.make(
+            "DashboardStats",
+            date_field_name="date_joined",
+            model_name="User",
+            model_app_name="auth",
+            operation_field_name=operation_field_name,
+        )
+
+    def test_blank_entries_are_skipped(self):
+        """A trailing comma leaves an empty operation, which is not a field"""
+        stats = self.make_stats("is_active,")
+        self.assertEqual(stats.get_operations_list(), ["is_active", ""])
+        stats.clean()
+
+    def test_unknown_operation_field_is_reported(self):
+        stats = self.make_stats("is_active,nonexistent")
+        with self.assertRaises(ValidationError) as error:
+            stats.clean()
+        self.assertIn("operation_field_name", error.exception.message_dict)
+
+
 class ControlFormTests(TestCase):
     def test_get_control_form_renders_the_fields(self):
         """get_control_form() renders the chart controls as HTML"""

--- a/admin_tools_stats/tests/test_views.py
+++ b/admin_tools_stats/tests/test_views.py
@@ -818,9 +818,8 @@ class CSVDownloadSuperuserTests(BaseSuperuserAuthenticatedClient):
         header = lines[2].split(",")
         self.assertEqual(header[0], "Date")
 
-        if len(lines) > 3:
-            data_row = lines[3].split(",")
-            self.assertIn("2010-10-10", data_row[0])
+        data_row = lines[3].split(",")
+        self.assertIn("2010-10-10", data_row[0])
 
     @override_settings(USE_TZ=True, TIME_ZONE="UTC")
     def test_csv_download_multiple_series(self):
@@ -1053,31 +1052,11 @@ class CachedChartsBugReproductionTests(BaseSuperuserAuthenticatedClient):
         content = response_csv.content.decode("utf-8")
         lines = content.strip().split("\r\n")
 
+        months = {}
         for line in lines[3:]:
-            if not line:
-                continue
-            parts = line.split(",")
-            if len(parts) < 2:
-                continue
-            date_str = parts[0]
-            value_str = parts[1]
+            date_str, value_str = line.split(",")[:2]
+            months[value_str] = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S").month
 
-            if value_str == "0" or value_str == "0.0":
-                continue
-
-            date_obj = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
-
-            if "100" in value_str:
-                self.assertEqual(
-                    date_obj.month,
-                    11,
-                    f"Value 100 is November data (Oct 31 23:00 UTC = Nov 1 00:00 CET). "
-                    f"Month should be 11, got {date_obj.month}. Date: {date_str}",
-                )
-            elif "200" in value_str:
-                self.assertEqual(
-                    date_obj.month,
-                    12,
-                    f"Value 200 is December data (Nov 30 23:00 UTC = Dec 1 00:00 CET). "
-                    f"Month should be 12, got {date_obj.month}. Date: {date_str}",
-                )
+        # Oct 31 23:00 UTC is Nov 1 00:00 CET, and Nov 30 23:00 UTC is Dec 1
+        # 00:00 CET: the cached values must be labelled with the local month
+        self.assertEqual(months, {"100.0": 11, "200.0": 12})


### PR DESCRIPTION
## Where it stood

After #102/#103/#104 the package had **no uncovered statements left** — 99%, made up entirely of four partial branches in `models.py` plus a few in the tests. This closes them.

## Covered by tests (real paths nothing exercised)

* **`transform_cached_values()` skipping the timezone conversion for naive dates**, which is exactly what `USE_TZ=False` stores in `CachedValue.date`. Both directions are now asserted: naive dates come back untouched, aware ones are converted to the chart timezone.
* **`clean()` walking past a blank entry in the operations list**, which a trailing comma in `operation_field_name` produces. The neighbouring case — an operation field that does not exist — is asserted alongside it, since that is what the branch exists to catch.

## Simplified, because the branch could not be reached

* **`get_series_query_parameters()`** tested for `list`/`tuple`, then for `str`, and left `single_value` **unbound** for anything else — so that third path could only ever have raised `UnboundLocalError`. It now treats "not a `str`" as the sequence case: identical for every input that can actually arrive, and with no way to crash.
* **`get_multi_time_series()`** guarded `series[time] = {}` with `if time not in series`. `get_time_series()` groups by the truncated date, so a date cannot repeat — and even if it did, the loop underneath rewrites every name. I didn't want to remove a guard on reasoning alone, so I ran both variants over duplicated input: identical output in every case, including two and three repeats of the same date.

## The tests had dead branches too

Replaced with stronger assertions rather than more `continue`s:

* the CSV month test now asserts the whole `{value: month}` mapping in one go (`{"100.0": 11, "200.0": 12}`) instead of looping over rows with an `if`/`elif` that only ever took two paths and silently asserted nothing for anything else
* the CSV header test asserts the data row **exists** instead of skipping the assertion when it doesn't

## Result

```
TOTAL   3204 stmts   0 miss   302 branch   0 partial   100%
```

Statements and branches, every file, measured the way CI does it — the union of a SQLite and a PostgreSQL run. 158 Python tests and 17 JS tests green on both backends; pre-commit, mypy and `makemigrations --check` clean.
