### PR TITLE
fix(recalculate_charts): survive a broken chart, report it at the end [Pre-vacation error review]

### DIFF
--- a/admin_tools_stats/management/commands/recalculate_charts.py
+++ b/admin_tools_stats/management/commands/recalculate_charts.py
@@ -1,4 +1,5 @@
 import time
+import traceback
 from datetime import datetime, timedelta
 
 from datetime_truncate import truncate
@@ -107,72 +108,89 @@ class Command(BaseCommand):
         )
         self.stdout.write(f"recalculating charts: \n{chart_string}")
         user = self.get_user(options)
+        failed_graph_keys = []
         for stats in stats_query:
-            operation = stats.type_operation_field_name
-            configuration = {
-                "select_box_chart_type": stats.default_chart_type,
-                "reload": "True",
-                "reload_all": str(options["reload_all"]),
-            }
-            for criteria in stats.criteriatostatsm2m_set.filter(
-                use_as="chart_filter",
-                criteria__dynamic_criteria_field_name__isnull=False,
-            ):
-                configuration[f"select_box_dynamic_{criteria.id}"] = criteria.default_option
+            # Charts are configuration data, editable in the admin at any
+            # time. One misconfigured chart must fail loudly but must not
+            # starve every chart after it of its recalculation.
+            try:
+                self.recalculate_stats(stats, options, user)
+            except Exception:
+                self.stdout.write(traceback.format_exc())
+                self.stdout.write(f"recalculation of '{stats.graph_key}' FAILED, continuing")
+                failed_graph_keys.append(stats.graph_key)
+        if failed_graph_keys:
+            raise CommandError(
+                f"{len(failed_graph_keys)} chart(s) failed to recalculate: "
+                + ", ".join(failed_graph_keys)
+            )
 
-            all_multiseries_criteria = self.get_all_multiseries_criteria(stats, options)
+    def recalculate_stats(self, stats, options, user):
+        operation = stats.type_operation_field_name
+        configuration = {
+            "select_box_chart_type": stats.default_chart_type,
+            "reload": "True",
+            "reload_all": str(options["reload_all"]),
+        }
+        for criteria in stats.criteriatostatsm2m_set.filter(
+            use_as="chart_filter",
+            criteria__dynamic_criteria_field_name__isnull=False,
+        ):
+            configuration[f"select_box_dynamic_{criteria.id}"] = criteria.default_option
 
-            self.stdout.write(f"recalculating {stats} controls")
-            if not options["dry_run"]:
-                stats.get_control_form_raw(user=user)
+        all_multiseries_criteria = self.get_all_multiseries_criteria(stats, options)
 
-            for multiseries_criteria in all_multiseries_criteria:
-                if multiseries_criteria:
-                    configuration["select_box_multiple_series"] = multiseries_criteria.id
+        self.stdout.write(f"recalculating {stats} controls")
+        if not options["dry_run"]:
+            stats.get_control_form_raw(user=user)
 
-                if options.get("time_ranges", None):
-                    time_scales = options["time_ranges"].split(",")
-                else:
-                    time_scales = stats.allowed_time_scales
+        for multiseries_criteria in all_multiseries_criteria:
+            if multiseries_criteria:
+                configuration["select_box_multiple_series"] = multiseries_criteria.id
 
-                chart_tz = get_charts_timezone()
-                operation_fields = stats.operation_field_name.split(",") + [""]
+            if options.get("time_ranges", None):
+                time_scales = options["time_ranges"].split(",")
+            else:
+                time_scales = stats.allowed_time_scales
 
-                for operation_field in operation_fields:
-                    for selected_interval in time_scales:
-                        start_time = time.time()
+            chart_tz = get_charts_timezone()
+            operation_fields = stats.operation_field_name.split(",") + [""]
 
-                        self.stdout.write(
-                            f"recalculating chart '{stats}' with '{multiseries_criteria}' on "
-                            f"'{operation_field}' criteria in {selected_interval}"
+            for operation_field in operation_fields:
+                for selected_interval in time_scales:
+                    start_time = time.time()
+
+                    self.stdout.write(
+                        f"recalculating chart '{stats}' with '{multiseries_criteria}' on "
+                        f"'{operation_field}' criteria in {selected_interval}"
+                    )
+                    time_since = datetime.now() - timedelta(
+                        days=stats.default_time_period
+                    ) * options.get("periods_count", 1)
+                    time_since = truncate(time_since, Interval(selected_interval).val())
+                    time_since = time_since.astimezone(chart_tz)
+
+                    if options.get("time_until", None):
+                        time_until = datetime.strptime(options["time_until"], "%Y-%m-%d").replace(
+                            hour=23, minute=59, second=59
                         )
-                        time_since = datetime.now() - timedelta(
-                            days=stats.default_time_period
-                        ) * options.get("periods_count", 1)
-                        time_since = truncate(time_since, Interval(selected_interval).val())
-                        time_since = time_since.astimezone(chart_tz)
+                    else:
+                        time_until = datetime.now()
+                    time_until = truncate_ceiling(time_until, Interval(selected_interval).val())
+                    time_until = time_until.astimezone(chart_tz)
 
-                        if options.get("time_until", None):
-                            time_until = datetime.strptime(
-                                options["time_until"], "%Y-%m-%d"
-                            ).replace(hour=23, minute=59, second=59)
-                        else:
-                            time_until = datetime.now()
-                        time_until = truncate_ceiling(time_until, Interval(selected_interval).val())
-                        time_until = time_until.astimezone(chart_tz)
+                    configuration["select_box_interval"] = selected_interval
+                    if not options["dry_run"]:
+                        stats.get_multi_time_series_cached(
+                            configuration=configuration,
+                            time_since=time_since,
+                            time_until=time_until,
+                            interval=Interval(selected_interval),
+                            operation_choice=operation,
+                            operation_field_choice=operation_field,
+                            user=user,
+                        )
 
-                        configuration["select_box_interval"] = selected_interval
-                        if not options["dry_run"]:
-                            stats.get_multi_time_series_cached(
-                                configuration=configuration,
-                                time_since=time_since,
-                                time_until=time_until,
-                                interval=Interval(selected_interval),
-                                operation_choice=operation,
-                                operation_field_choice=operation_field,
-                                user=user,
-                            )
-
-                        end_time = time.time()
-                        duration = end_time - start_time
-                        self.stdout.write(f"  -> Recalculation took {duration:.2f} seconds")
+                    end_time = time.time()
+                    duration = end_time - start_time
+                    self.stdout.write(f"  -> Recalculation took {duration:.2f} seconds")

--- a/admin_tools_stats/tests/test_commands.py
+++ b/admin_tools_stats/tests/test_commands.py
@@ -143,3 +143,76 @@ class RecalculateChartsTests(TestCase):
         output = self.call("--time-ranges", "days", "--exclude", "user_graph")
         self.assertNotIn("user_graph", output)
         self.assertFalse(CachedValue.objects.exists())
+
+
+class RecalculateChartsBrokenChartTests(TestCase):
+    """One misconfigured chart must not starve every other chart.
+
+    Charts are configuration data anyone can edit in the admin. In production
+    a single criteria with an unresolvable field name killed the whole weekly
+    recalculation for ten weeks straight: every chart ordered after the broken
+    one silently kept its stale cache, and the admin dashboards fell back to
+    computing on demand (30+ second page loads).
+    """
+
+    def setUp(self):
+        self.broken = baker.make(
+            "DashboardStats",
+            date_field_name="date_joined",
+            graph_title="Broken chart",
+            model_name="User",
+            model_app_name="auth",
+            graph_key="broken_graph",
+            type_operation_field_name="Count",
+            operation_field_name="id",
+            cache_values=True,
+            show_to_users=False,
+        )
+        criteria = baker.make(
+            "DashboardStatsCriteria",
+            criteria_name="No such field",
+            dynamic_criteria_field_name="no_such_field",
+        )
+        baker.make(
+            "CriteriaToStatsM2M",
+            criteria=criteria,
+            stats=self.broken,
+            use_as="multiple_series",
+            recalculate=True,
+        )
+        self.healthy = baker.make(
+            "DashboardStats",
+            date_field_name="date_joined",
+            graph_title="Healthy chart",
+            model_name="User",
+            model_app_name="auth",
+            graph_key="healthy_graph",
+            type_operation_field_name="Count",
+            operation_field_name="id",
+            cache_values=True,
+            show_to_users=False,
+        )
+        baker.make(
+            "User",
+            username="admin",
+            is_superuser=True,
+            date_joined=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        )
+
+    def test_broken_chart_does_not_stop_the_others(self):
+        """The healthy chart is still recalculated and the failure is reported."""
+        out = StringIO()
+        with self.assertRaises(CommandError) as error:
+            call_command("recalculate_charts", "--time-ranges", "days", stdout=out)
+
+        self.assertTrue(CachedValue.objects.filter(stats=self.healthy).exists())
+        self.assertIn("broken_graph", str(error.exception))
+        self.assertIn("1 chart(s) failed to recalculate", str(error.exception))
+        self.assertIn("no_such_field", out.getvalue())
+
+    def test_all_healthy_charts_still_exit_cleanly(self):
+        """Without a broken chart the command keeps its zero exit code."""
+        self.broken.delete()
+        out = StringIO()
+        call_command("recalculate_charts", "--time-ranges", "days", stdout=out)
+        self.assertTrue(CachedValue.objects.filter(stats=self.healthy).exists())


### PR DESCRIPTION
## One broken chart starved every other chart for ten weeks

`recalculate_charts` iterates the cached charts and lets the first exception kill the whole run. Charts (and their criteria) are configuration data, editable in the admin at any time — so any admin edit can break the *entire* recalculation, silently, forever.

That is not hypothetical: in production (blenderkit.com) a criteria with a related-path field plus `count_limit` (the resolution bug already fixed on master by the `related_field_name` split, covered by `test_get_multi_series_count_limit_related_field`) crashed the weekly run **every Saturday for at least ten weeks**. Every chart ordered after the broken one kept its stale cache, and the admin dashboards fell back to computing charts on demand — 30+ second page loads for whoever opened them. The scheduler alert fired weekly but only said "the task failed", never which chart.

## Change

- Extract the per-chart body of `handle()` into `recalculate_stats()` (mechanical move, dedented one level — best viewed with whitespace-ignoring diff).
- Guard each chart: on failure, print the traceback and `recalculation of '<graph_key>' FAILED, continuing`, keep going.
- After the loop, if anything failed, raise `CommandError` naming every failed graph_key — the exit code stays non-zero so schedulers still alert, but the alert now names the culprit instead of starving the healthy charts.

## Tests

New `RecalculateChartsBrokenChartTests` (written first, red before the change):

- a chart with an unresolvable dynamic criteria field no longer prevents the healthy chart's `CachedValue` from being written; the `CommandError` lists the broken graph_key and the count; the traceback lands in stdout;
- with no broken chart the command still exits cleanly (guards against the wrapper swallowing the zero-exit path).

`admin_tools_stats/tests/test_commands.py`: 11 passed. Full suite: 151 passed + the same 6 failures master already has without this change (fixture/view tests, environment-dependent — verified by stash/re-run). pre-commit (isort, black, flake8): clean.
