### PR TITLE
feat(ux): grouped chart filter bar without jQuery [Rework admin-charts PR #92 UX]

### DIFF
--- a/admin_tools_stats/forms.py
+++ b/admin_tools_stats/forms.py
@@ -21,6 +21,8 @@ class ChartSettingsForm(forms.Form):
                     "class"
                 ] = "chart-input"
 
+        self.has_chart_filters = any(name.startswith("select_box_dynamic_") for name in self.fields)
+
         self.fields["graph_key"] = forms.CharField(
             initial=stats.graph_key,
             widget=forms.HiddenInput(attrs={"class": "hidden_graph_key"}),

--- a/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
+++ b/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
@@ -215,10 +215,106 @@ function loadAnchor(element){
    loadChart(form, graph_key, reload, is_analytics);
 }
 
+function filterChips(form) {
+   return Array.prototype.slice.call(form.querySelectorAll('.chart-filter-removable'));
+}
+
+function updateAddFilterDropdown(form) {
+   const wrapper = form.querySelector('.chart-add-filter');
+   if (!wrapper) {
+      return;
+   }
+   const dropdown = wrapper.querySelector('.chart-add-filter-dropdown');
+   dropdown.innerHTML = '';
+   filterChips(form).forEach(function(chip) {
+      if (chip.style.display !== 'none') {
+         return;
+      }
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'chart-add-filter-option';
+      option.textContent = chip.dataset.filterLabel;
+      option.dataset.filterName = chip.dataset.filterName;
+      dropdown.appendChild(option);
+   });
+   wrapper.style.display = dropdown.children.length ? '' : 'none';
+}
+
+function closeAddFilterDropdowns(except) {
+   document.querySelectorAll('.chart-add-filter-dropdown.show').forEach(function(dropdown) {
+      if (dropdown !== except) {
+         dropdown.classList.remove('show');
+         const button = dropdown.parentElement.querySelector('.chart-add-filter-btn');
+         if (button) {
+            button.setAttribute('aria-expanded', 'false');
+         }
+      }
+   });
+}
+
+function toggleAddFilterDropdown(button) {
+   const dropdown = button.parentElement.querySelector('.chart-add-filter-dropdown');
+   closeAddFilterDropdowns(dropdown);
+   const show = !dropdown.classList.contains('show');
+   dropdown.classList.toggle('show', show);
+   button.setAttribute('aria-expanded', show ? 'true' : 'false');
+}
+
+function addFilter(option) {
+   const form = option.closest('form.stateform');
+   const chip = form.querySelector(
+      '.chart-filter-removable[data-filter-name="' + option.dataset.filterName + '"]'
+   );
+   if (!chip) {
+      return;
+   }
+   chip.style.display = '';
+   const select = chip.querySelector('select');
+   if (select) {
+      const firstChoice = Array.prototype.find.call(select.options, function(o) {
+         return o.value !== '';
+      });
+      if (firstChoice) {
+         select.value = firstChoice.value;
+      }
+   }
+   closeAddFilterDropdowns();
+   updateAddFilterDropdown(form);
+   loadAnchor(form);
+}
+
+function removeFilter(button) {
+   const chip = button.closest('.chart-filter-removable');
+   const form = button.closest('form.stateform');
+   const select = chip.querySelector('select');
+   const hadValue = select && select.value !== '';
+   if (select) {
+      select.value = '';
+   }
+   chip.style.display = 'none';
+   updateAddFilterDropdown(form);
+   if (hadValue) {
+      loadAnchor(form);
+   }
+}
+
+// a filter whose select carries no value does not constrain the chart, so it
+// starts folded away behind the "+ Add filter" button
+function hideEmptyFilters(form) {
+   filterChips(form).forEach(function(chip) {
+      const select = chip.querySelector('select');
+      if (select && select.value === '') {
+         chip.style.display = 'none';
+      }
+   });
+   updateAddFilterDropdown(form);
+}
+
 function loadChartForms(chartElement, chart_key){
    visibleForms(chartElement).forEach(function(form) {
       populateFormFromUrl(form, chart_key);
       updateAnalyticsLink(form, chart_key);
+      hideEmptyFilters(form);
       loadAnchor(form);
    });
 }
@@ -289,12 +385,15 @@ defer( function(){
    onReady(function() {
 
       document.body.addEventListener('change', function(event) {
-         if (event.target.matches('#load_on_change:checked ~ .chart-input')) {
+         if (event.target.matches('.chart-input')) {
             loadAnchor(event.target);
          }
       });
 
       document.body.addEventListener('click', function(event) {
+         if (!event.target.closest('.chart-add-filter')) {
+            closeAddFilterDropdowns();
+         }
          const reloadButton = event.target.closest('.reload');
          if (reloadButton) {
             loadAnchor(reloadButton);
@@ -303,10 +402,32 @@ defer( function(){
          const csvLink = event.target.closest('.download-csv');
          if (csvLink) {
             downloadCSV(event, csvLink);
+            return;
+         }
+         const removeButton = event.target.closest('.chart-filter-remove-btn');
+         if (removeButton) {
+            removeFilter(removeButton);
+            return;
+         }
+         const addOption = event.target.closest('.chart-add-filter-option');
+         if (addOption) {
+            addFilter(addOption);
+            return;
+         }
+         const addButton = event.target.closest('.chart-add-filter-btn');
+         if (addButton) {
+            toggleAddFilterDropdown(addButton);
+         }
+      });
+
+      document.addEventListener('keydown', function(event) {
+         if (event.key === 'Escape') {
+            closeAddFilterDropdowns();
          }
       });
 
       visibleForms(document).forEach(function(form) {
+         hideEmptyFilters(form);
          loadAnchor(form);
       });
    });

--- a/admin_tools_stats/templates/admin_tools_stats/chart_form.html
+++ b/admin_tools_stats/templates/admin_tools_stats/chart_form.html
@@ -17,20 +17,317 @@
                 50% 50%
                 no-repeat;
     }
+
+    .chart-filter-bar {
+        border: 1px solid var(--border-color, #ddd);
+        padding: 12px 15px;
+        background: var(--darkened-bg, #f8f8f8);
+        border-radius: 4px;
+        display: flex;
+        align-items: center;
+        gap: 15px;
+        flex-wrap: wrap;
+        max-width: 100%;
+    }
+
+    .chart-filter-sections {
+        display: flex;
+        gap: 15px;
+        flex-wrap: wrap;
+        flex: 1;
+        align-items: center;
+        min-width: 0;
+    }
+
+    .chart-filter-section {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        padding-right: 15px;
+        border-right: 1px solid var(--border-color, #ddd);
+        flex-wrap: wrap;
+        min-width: 0;
+    }
+
+    .chart-filter-section:last-child {
+        border-right: none;
+        padding-right: 0;
+    }
+
+    .chart-filter-control {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .chart-filter-control label,
+    .chart-filter-removable label {
+        font-size: 11px;
+        color: var(--body-quiet-color, #999);
+        font-weight: 400;
+        white-space: nowrap;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+
+    .chart-filter-bar select,
+    .chart-filter-bar input[type="date"] {
+        padding: 4px 6px;
+        border: 1px solid var(--border-color, #ccc);
+        border-radius: 3px;
+        font-size: 13px;
+        background: var(--body-bg, white);
+        color: var(--body-fg, #333);
+        cursor: pointer;
+        max-width: 200px;
+    }
+
+    .chart-filter-bar select:hover,
+    .chart-filter-bar input[type="date"]:hover {
+        border-color: var(--body-quiet-color, #417690);
+    }
+
+    .chart-filter-bar select:focus,
+    .chart-filter-bar input[type="date"]:focus {
+        outline: none;
+        border-color: var(--primary, #417690);
+        box-shadow: 0 0 0 2px rgba(65, 118, 144, 0.2);
+    }
+
+    .chart-filter-removable {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        background: var(--body-bg, white);
+        border: 1px solid var(--border-color, #ddd);
+        border-radius: 4px;
+        padding: 4px 4px 4px 8px;
+    }
+
+    .chart-filter-remove-btn {
+        background: none;
+        border: none;
+        color: var(--body-quiet-color, #999);
+        font-size: 16px;
+        line-height: 1;
+        padding: 0 4px;
+        cursor: pointer;
+    }
+
+    .chart-filter-remove-btn:hover {
+        color: var(--error-fg, #dc3545);
+    }
+
+    .chart-time-range {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .chart-time-range input[type="date"] {
+        width: 135px;
+    }
+
+    .chart-time-range-separator {
+        color: var(--body-quiet-color, #999);
+        font-weight: bold;
+    }
+
+    .chart-filter-actions {
+        display: flex;
+        gap: 6px;
+        margin-left: auto;
+        align-items: center;
+    }
+
+    .chart-filter-actions button,
+    .chart-filter-actions a {
+        padding: 5px 10px;
+        border: 1px solid var(--border-color, #ccc);
+        background: var(--body-bg, white);
+        border-radius: 3px;
+        cursor: pointer;
+        text-decoration: none;
+        color: var(--body-fg, #333);
+        font-size: 13px;
+    }
+
+    .chart-filter-actions button:hover,
+    .chart-filter-actions a:hover {
+        background: var(--darkened-bg, #f0f0f0);
+    }
+
+    .chart-add-filter {
+        position: relative;
+        display: inline-block;
+    }
+
+    .chart-add-filter-btn {
+        background: transparent;
+        border: 1px dashed var(--primary, #417690);
+        color: var(--primary, #417690);
+        padding: 4px 10px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px;
+        font-weight: 500;
+    }
+
+    .chart-add-filter-btn:hover {
+        background: var(--darkened-bg, #f0f7fa);
+        border-style: solid;
+    }
+
+    .chart-add-filter-dropdown {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        margin-top: 4px;
+        background: var(--body-bg, white);
+        border: 1px solid var(--border-color, #ddd);
+        border-radius: 4px;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        padding: 4px;
+        z-index: 1000;
+        display: none;
+        min-width: 180px;
+    }
+
+    .chart-add-filter-dropdown.show {
+        display: block;
+    }
+
+    .chart-add-filter-option {
+        display: block;
+        width: 100%;
+        text-align: left;
+        border: none;
+        background: none;
+        color: var(--body-fg, #333);
+        padding: 6px 10px;
+        cursor: pointer;
+        border-radius: 3px;
+        font-size: 13px;
+    }
+
+    .chart-add-filter-option:hover,
+    .chart-add-filter-option:focus {
+        background: var(--selected-row, #f0f7fa);
+    }
+
+    @media (max-width: 768px) {
+        .chart-filter-bar {
+            padding: 8px 10px;
+            gap: 8px;
+        }
+
+        .chart-filter-sections {
+            gap: 8px;
+        }
+
+        .chart-filter-section {
+            border-right: none;
+            padding-right: 0;
+            gap: 6px;
+        }
+
+        .chart-filter-control label,
+        .chart-filter-removable label {
+            display: none;
+        }
+
+        .chart-filter-bar select,
+        .chart-filter-bar input[type="date"] {
+            font-size: 12px;
+            padding: 4px 6px;
+        }
+
+        .chart-time-range input[type="date"] {
+            width: 110px;
+        }
+
+        .chart-filter-actions {
+            margin-left: 0;
+            width: 100%;
+            justify-content: flex-end;
+        }
+    }
 </style>
-<form class="stateform" action="." method="POST" enctype="multipart/form-data">
-   <input id="load_on_change" title="Load on change" checked type="checkbox"/>⇒&nbsp;
+<form class="stateform chart-filter-bar" action="." method="POST" enctype="multipart/form-data">
    {% csrf_token %}
-   {% for w in form %}
-      {% if not w.is_hidden %}
-      {{ w.label }}:
+
+   <div class="chart-filter-sections">
+      {% if form.select_box_chart_type %}
+      <div class="chart-filter-section">
+         <div class="chart-filter-control">
+            {{ form.select_box_chart_type }}
+         </div>
+      </div>
       {% endif %}
-      {{ w }}
-   {% endfor %}
-   &nbsp;<button class="reload" id="reload" title="reload values from unfinished periods" type="button" style="font-size:14px">⟳</button>
-   {% if chart.cache_values %}
-   &nbsp;<button class="reload" id="reload_all" title="reload all visible values" type="button" style="font-size:14px">⟳ all</button>
-   {% endif %}
-   &nbsp;<a href='{% url 'chart-analytics' %}?show={{ chart.graph_key }}' target='_blank'>analytics</a>
-   &nbsp;<a href='#' class="download-csv" data-graph-key="{{ chart.graph_key }}" title="Download chart data as CSV">📥 CSV</a>
+
+      <div class="chart-filter-section">
+         {% if form.select_box_interval %}
+         <div class="chart-filter-control">
+            {{ form.select_box_interval }}
+         </div>
+         {% endif %}
+         <div class="chart-time-range">
+            {{ form.time_since }}
+            <span class="chart-time-range-separator">→</span>
+            {{ form.time_until }}
+         </div>
+      </div>
+
+      {% if form.select_box_operation or form.select_box_operation_field or form.select_box_multiple_series %}
+      <div class="chart-filter-section">
+         {% if form.select_box_operation %}
+         <div class="chart-filter-control">
+            <label>{{ form.select_box_operation.label }}</label>
+            {{ form.select_box_operation }}
+         </div>
+         {% endif %}
+         {% if form.select_box_operation_field %}
+         <div class="chart-filter-control">
+            <label>{{ form.select_box_operation_field.label }}</label>
+            {{ form.select_box_operation_field }}
+         </div>
+         {% endif %}
+         {% if form.select_box_multiple_series %}
+         <div class="chart-filter-control">
+            <label>{{ form.select_box_multiple_series.label }}</label>
+            {{ form.select_box_multiple_series }}
+         </div>
+         {% endif %}
+      </div>
+      {% endif %}
+
+      {% if form.has_chart_filters %}
+      <div class="chart-filter-section chart-filters-section">
+         {% for field in form %}
+            {% if "select_box_dynamic" in field.name and not field.is_hidden %}
+               <div class="chart-filter-removable" data-filter-name="{{ field.name }}" data-filter-label="{{ field.label }}">
+                  <label>{{ field.label }}</label>
+                  {{ field }}
+                  <button type="button" class="chart-filter-remove-btn" data-field="{{ field.name }}" title="Remove filter">×</button>
+               </div>
+            {% endif %}
+         {% endfor %}
+         <span class="chart-add-filter">
+            <button type="button" class="chart-add-filter-btn" aria-haspopup="true" aria-expanded="false">+ Add filter</button>
+            <div class="chart-add-filter-dropdown"></div>
+         </span>
+      </div>
+      {% endif %}
+   </div>
+
+   <div class="chart-filter-actions">
+      <button class="reload" id="reload" title="reload values from unfinished periods" type="button">⟳</button>
+      {% if chart.cache_values %}
+      <button class="reload" id="reload_all" title="reload all visible values" type="button">⟳ all</button>
+      {% endif %}
+      <a href='{% url 'chart-analytics' %}?show={{ chart.graph_key }}' target='_blank' title="Open in analytics">📊 analytics</a>
+      <a href='#' class="download-csv" data-graph-key="{{ chart.graph_key }}" title="Download chart data as CSV">📥 CSV</a>
+   </div>
+
+   {{ form.graph_key }}
 </form>

--- a/admin_tools_stats/tests/test_forms.py
+++ b/admin_tools_stats/tests/test_forms.py
@@ -16,6 +16,7 @@ class ChartSettingsFormTests(TestCase):
             ch.fields["select_box_operation_field"].choices,
             [("", "(divide all)"), ("auth", "auth"), ("user", "user")],
         )
+        self.assertFalse(ch.has_chart_filters)
 
     def test_chart_filter_and_multiple_series_fields(self):
         """Criteria of the chart add a filter select and the "Divide" select"""
@@ -55,6 +56,7 @@ class ChartSettingsFormTests(TestCase):
             [("", "-------"), ("", "All"), (True, "True"), (False, "False")],
         )
         self.assertEqual(filter_field.widget.attrs["class"], "chart-input")
+        self.assertTrue(ch.has_chart_filters)
 
         divide_field = ch.fields["select_box_multiple_series"]
         self.assertEqual(divide_field.label, "Divide")

--- a/js_tests/admin_charts.test.mjs
+++ b/js_tests/admin_charts.test.mjs
@@ -38,10 +38,13 @@ describe("form serialization", () => {
         assert.ok(params.has("select_box_interval"));
     });
 
-    it("skips the load-on-change checkbox, which carries no name", async () => {
+    it("skips the folded-away filters only by their empty value, not their fields", async () => {
         const win = chartPage();
         await settle();
-        assert.ok(!lastRequest(win).url.includes("load_on_change"));
+        // the empty filter is folded away visually but still submits its
+        // (empty) field, so the chart data view sees a stable parameter set
+        const params = new URLSearchParams(lastRequest(win).url.split("?")[1]);
+        assert.equal(params.get("select_box_dynamic_1"), "");
     });
 });
 
@@ -88,8 +91,8 @@ describe("reload buttons", () => {
     });
 });
 
-describe("load on change", () => {
-    it("reloads the chart when a control changes and the checkbox is ticked", async () => {
+describe("direct editing", () => {
+    it("reloads the chart as soon as a control changes", async () => {
         const win = chartPage();
         await settle();
         win.requests.length = 0;
@@ -102,19 +105,102 @@ describe("load on change", () => {
         assert.equal(win.requests.length, 1);
         assert.ok(lastRequest(win).url.includes("time_since=2021-01-01"), lastRequest(win).url);
     });
+});
 
-    it("does nothing when the checkbox is unticked", async () => {
+describe("filter chips", () => {
+    function chip(win) {
+        return win.document.querySelector(".chart-filter-removable");
+    }
+    function addButton(win) {
+        return win.document.querySelector(".chart-add-filter-btn");
+    }
+    function dropdown(win) {
+        return win.document.querySelector(".chart-add-filter-dropdown");
+    }
+
+    it("folds an empty filter away behind the add button on load", async () => {
         const win = chartPage();
         await settle();
-        win.document.getElementById("load_on_change").checked = false;
+
+        assert.equal(chip(win).style.display, "none");
+        const options = dropdown(win).querySelectorAll(".chart-add-filter-option");
+        assert.equal(options.length, 1);
+        assert.equal(options[0].textContent, "active");
+    });
+
+    it("adds a filter back with its first real choice and reloads the chart", async () => {
+        const win = chartPage();
+        await settle();
         win.requests.length = 0;
 
-        const input = win.document.querySelector('[name="time_since"]');
-        input.value = "2022-02-02";
-        input.dispatchEvent(new win.Event("change", { bubbles: true }));
+        addButton(win).click();
+        assert.ok(dropdown(win).classList.contains("show"));
+        assert.equal(addButton(win).getAttribute("aria-expanded"), "true");
+
+        dropdown(win).querySelector(".chart-add-filter-option").click();
+        await settle();
+
+        assert.equal(chip(win).style.display, "");
+        assert.equal(chip(win).querySelector("select").value, "True");
+        assert.ok(!dropdown(win).classList.contains("show"));
+        assert.ok(
+            lastRequest(win).url.includes("select_box_dynamic_1=True"),
+            lastRequest(win).url
+        );
+        // nothing left to add: the button folds away too
+        assert.equal(addButton(win).closest(".chart-add-filter").style.display, "none");
+    });
+
+    it("removes a filter: clears its value, hides the chip and reloads", async () => {
+        const win = chartPage();
+        await settle();
+        const select = chip(win).querySelector("select");
+        chip(win).style.display = "";
+        select.value = "True";
+        win.requests.length = 0;
+
+        chip(win).querySelector(".chart-filter-remove-btn").click();
+        await settle();
+
+        assert.equal(select.value, "");
+        assert.equal(chip(win).style.display, "none");
+        assert.equal(win.requests.length, 1);
+        assert.ok(
+            lastRequest(win).url.includes("select_box_dynamic_1=&"),
+            lastRequest(win).url
+        );
+        assert.equal(dropdown(win).querySelectorAll(".chart-add-filter-option").length, 1);
+    });
+
+    it("does not reload when removing a filter that was already empty", async () => {
+        const win = chartPage();
+        await settle();
+        chip(win).style.display = "";
+        win.requests.length = 0;
+
+        chip(win).querySelector(".chart-filter-remove-btn").click();
         await settle();
 
         assert.equal(win.requests.length, 0);
+        assert.equal(chip(win).style.display, "none");
+    });
+
+    it("closes the dropdown on an outside click and on Escape", async () => {
+        const win = chartPage();
+        await settle();
+
+        addButton(win).click();
+        assert.ok(dropdown(win).classList.contains("show"));
+        win.document.body.click();
+        assert.ok(!dropdown(win).classList.contains("show"));
+        assert.equal(addButton(win).getAttribute("aria-expanded"), "false");
+
+        addButton(win).click();
+        assert.ok(dropdown(win).classList.contains("show"));
+        win.document.dispatchEvent(
+            new win.KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+        );
+        assert.ok(!dropdown(win).classList.contains("show"));
     });
 });
 

--- a/js_tests/fixtures/chart_form.html
+++ b/js_tests/fixtures/chart_form.html
@@ -22,50 +22,250 @@
                 50% 50%
                 no-repeat;
     }
+
+    .chart-filter-bar {
+        border: 1px solid var(--border-color, #ddd);
+        padding: 12px 15px;
+        background: var(--darkened-bg, #f8f8f8);
+        border-radius: 4px;
+        display: flex;
+        align-items: center;
+        gap: 15px;
+        flex-wrap: wrap;
+        max-width: 100%;
+    }
+
+    .chart-filter-sections {
+        display: flex;
+        gap: 15px;
+        flex-wrap: wrap;
+        flex: 1;
+        align-items: center;
+        min-width: 0;
+    }
+
+    .chart-filter-section {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        padding-right: 15px;
+        border-right: 1px solid var(--border-color, #ddd);
+        flex-wrap: wrap;
+        min-width: 0;
+    }
+
+    .chart-filter-section:last-child {
+        border-right: none;
+        padding-right: 0;
+    }
+
+    .chart-filter-control {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .chart-filter-control label,
+    .chart-filter-removable label {
+        font-size: 11px;
+        color: var(--body-quiet-color, #999);
+        font-weight: 400;
+        white-space: nowrap;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+
+    .chart-filter-bar select,
+    .chart-filter-bar input[type="date"] {
+        padding: 4px 6px;
+        border: 1px solid var(--border-color, #ccc);
+        border-radius: 3px;
+        font-size: 13px;
+        background: var(--body-bg, white);
+        color: var(--body-fg, #333);
+        cursor: pointer;
+        max-width: 200px;
+    }
+
+    .chart-filter-bar select:hover,
+    .chart-filter-bar input[type="date"]:hover {
+        border-color: var(--body-quiet-color, #417690);
+    }
+
+    .chart-filter-bar select:focus,
+    .chart-filter-bar input[type="date"]:focus {
+        outline: none;
+        border-color: var(--primary, #417690);
+        box-shadow: 0 0 0 2px rgba(65, 118, 144, 0.2);
+    }
+
+    .chart-filter-removable {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        background: var(--body-bg, white);
+        border: 1px solid var(--border-color, #ddd);
+        border-radius: 4px;
+        padding: 4px 4px 4px 8px;
+    }
+
+    .chart-filter-remove-btn {
+        background: none;
+        border: none;
+        color: var(--body-quiet-color, #999);
+        font-size: 16px;
+        line-height: 1;
+        padding: 0 4px;
+        cursor: pointer;
+    }
+
+    .chart-filter-remove-btn:hover {
+        color: var(--error-fg, #dc3545);
+    }
+
+    .chart-time-range {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .chart-time-range input[type="date"] {
+        width: 135px;
+    }
+
+    .chart-time-range-separator {
+        color: var(--body-quiet-color, #999);
+        font-weight: bold;
+    }
+
+    .chart-filter-actions {
+        display: flex;
+        gap: 6px;
+        margin-left: auto;
+        align-items: center;
+    }
+
+    .chart-filter-actions button,
+    .chart-filter-actions a {
+        padding: 5px 10px;
+        border: 1px solid var(--border-color, #ccc);
+        background: var(--body-bg, white);
+        border-radius: 3px;
+        cursor: pointer;
+        text-decoration: none;
+        color: var(--body-fg, #333);
+        font-size: 13px;
+    }
+
+    .chart-filter-actions button:hover,
+    .chart-filter-actions a:hover {
+        background: var(--darkened-bg, #f0f0f0);
+    }
+
+    .chart-add-filter {
+        position: relative;
+        display: inline-block;
+    }
+
+    .chart-add-filter-btn {
+        background: transparent;
+        border: 1px dashed var(--primary, #417690);
+        color: var(--primary, #417690);
+        padding: 4px 10px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px;
+        font-weight: 500;
+    }
+
+    .chart-add-filter-btn:hover {
+        background: var(--darkened-bg, #f0f7fa);
+        border-style: solid;
+    }
+
+    .chart-add-filter-dropdown {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        margin-top: 4px;
+        background: var(--body-bg, white);
+        border: 1px solid var(--border-color, #ddd);
+        border-radius: 4px;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        padding: 4px;
+        z-index: 1000;
+        display: none;
+        min-width: 180px;
+    }
+
+    .chart-add-filter-dropdown.show {
+        display: block;
+    }
+
+    .chart-add-filter-option {
+        display: block;
+        width: 100%;
+        text-align: left;
+        border: none;
+        background: none;
+        color: var(--body-fg, #333);
+        padding: 6px 10px;
+        cursor: pointer;
+        border-radius: 3px;
+        font-size: 13px;
+    }
+
+    .chart-add-filter-option:hover,
+    .chart-add-filter-option:focus {
+        background: var(--selected-row, #f0f7fa);
+    }
+
+    @media (max-width: 768px) {
+        .chart-filter-bar {
+            padding: 8px 10px;
+            gap: 8px;
+        }
+
+        .chart-filter-sections {
+            gap: 8px;
+        }
+
+        .chart-filter-section {
+            border-right: none;
+            padding-right: 0;
+            gap: 6px;
+        }
+
+        .chart-filter-control label,
+        .chart-filter-removable label {
+            display: none;
+        }
+
+        .chart-filter-bar select,
+        .chart-filter-bar input[type="date"] {
+            font-size: 12px;
+            padding: 4px 6px;
+        }
+
+        .chart-time-range input[type="date"] {
+            width: 110px;
+        }
+
+        .chart-filter-actions {
+            margin-left: 0;
+            width: 100%;
+            justify-content: flex-end;
+        }
+    }
 </style>
-<form class="stateform" action="." method="POST" enctype="multipart/form-data">
-   <input id="load_on_change" title="Load on change" checked type="checkbox"/>⇒&nbsp;
+<form class="stateform chart-filter-bar" action="." method="POST" enctype="multipart/form-data">
    <input type="hidden" name="csrfmiddlewaretoken" value="TEST-CSRF-TOKEN">
 
+   <div class="chart-filter-sections">
 
-      active:
-
-      <select name="select_box_dynamic_1" class="chart-input" required>
-  <option value="" selected>-------</option>
-
-  <option value="">All</option>
-
-  <option value="True">True</option>
-
-  <option value="False">False</option>
-
-</select>
-
-
-      <input type="hidden" name="graph_key" value="g1" class="hidden_graph_key">
-
-
-      Scale:
-
-      <select name="select_box_interval" class="chart-input">
-  <option value="hours">Hours</option>
-
-  <option value="days" selected>Days</option>
-
-  <option value="weeks">Weeks</option>
-
-  <option value="months">Months</option>
-
-  <option value="quarters">Quarters</option>
-
-  <option value="years">Years</option>
-
-</select>
-
-
-      Chart:
-
-      <select name="select_box_chart_type" class="chart-input select_box_chart_type">
+      <div class="chart-filter-section">
+         <div class="chart-filter-control">
+            <select name="select_box_chart_type" class="chart-input select_box_chart_type">
   <option value="discreteBarChart" selected>Bar</option>
 
   <option value="lineChart">Line</option>
@@ -87,23 +287,86 @@
   <option value="lineWithFocusChart">Line With Focus</option>
 
 </select>
+         </div>
+      </div>
 
 
-      Since:
+      <div class="chart-filter-section">
 
-      <input type="date" name="time_since" value="2026-06-30" class="chart-input select_box_date_since" required>
+         <div class="chart-filter-control">
+            <select name="select_box_interval" class="chart-input">
+  <option value="hours">Hours</option>
+
+  <option value="days" selected>Days</option>
+
+  <option value="weeks">Weeks</option>
+
+  <option value="months">Months</option>
+
+  <option value="quarters">Quarters</option>
+
+  <option value="years">Years</option>
+
+</select>
+         </div>
+
+         <div class="chart-time-range">
+            <input type="date" name="time_since" value="2026-07-02" class="chart-input select_box_date_since" required>
+            <span class="chart-time-range-separator">→</span>
+            <input type="date" name="time_until" value="2026-08-02" class="chart-input select_box_date_until" required>
+         </div>
+      </div>
 
 
-      Until:
 
-      <input type="date" name="time_until" value="2026-07-31" class="chart-input select_box_date_until" required>
 
-   &nbsp;<button class="reload" id="reload" title="reload values from unfinished periods" type="button" style="font-size:14px">⟳</button>
+      <div class="chart-filter-section chart-filters-section">
 
-   &nbsp;<button class="reload" id="reload_all" title="reload all visible values" type="button" style="font-size:14px">⟳ all</button>
 
-   &nbsp;<a href='/admin_tools_stats/analytics/?show=g1' target='_blank'>analytics</a>
-   &nbsp;<a href='#' class="download-csv" data-graph-key="g1" title="Download chart data as CSV">📥 CSV</a>
+               <div class="chart-filter-removable" data-filter-name="select_box_dynamic_1" data-filter-label="active">
+                  <label>active</label>
+                  <select name="select_box_dynamic_1" class="chart-input" required>
+  <option value="" selected>-------</option>
+
+  <option value="">All</option>
+
+  <option value="True">True</option>
+
+  <option value="False">False</option>
+
+</select>
+                  <button type="button" class="chart-filter-remove-btn" data-field="select_box_dynamic_1" title="Remove filter">×</button>
+               </div>
+
+
+
+
+
+
+
+
+
+
+
+
+         <span class="chart-add-filter">
+            <button type="button" class="chart-add-filter-btn" aria-haspopup="true" aria-expanded="false">+ Add filter</button>
+            <div class="chart-add-filter-dropdown"></div>
+         </span>
+      </div>
+
+   </div>
+
+   <div class="chart-filter-actions">
+      <button class="reload" id="reload" title="reload values from unfinished periods" type="button">⟳</button>
+
+      <button class="reload" id="reload_all" title="reload all visible values" type="button">⟳ all</button>
+
+      <a href='/admin_tools_stats/analytics/?show=g1' target='_blank' title="Open in analytics">📊 analytics</a>
+      <a href='#' class="download-csv" data-graph-key="g1" title="Download chart data as CSV">📥 CSV</a>
+   </div>
+
+   <input type="hidden" name="graph_key" value="g1" class="hidden_graph_key">
 </form>
 
 


### PR DESCRIPTION
Rework of #92 on top of current master (v1.7.0), which dropped jQuery after that PR was written.

## What this brings from #92

- The chart form becomes a grouped filter bar: **chart type | period (scale + date range) | data (operation, field, divide) | filters**.
- Dynamic filters render as removable chips with an × button.
- A filter whose select carries no value does not constrain the chart, so it starts folded away behind a **“+ Add filter”** button; adding it back preselects its first real choice and reloads the chart.
- Direct editing: every control change applies immediately; the load-on-change checkbox is gone.
- Mobile layout: labels hide, controls compact, actions wrap onto their own row.

## UX / correctness fixes over #92

- **No jQuery** — everything reimplemented in vanilla JS on the current event-delegation setup; the `no jQuery` test guards still pass.
- The add-filter dropdown was a `<div>` nested **inside** a `<button>` (invalid HTML) positioned `fixed` with hand-computed coordinates. It is now a sibling in a `position:relative` wrapper, and its options are real buttons (keyboard-focusable).
- New controls carry **classes, not ids** — #92 added `#add-filter-btn`/`#add-filter-dropdown`/`#filters-section`, which duplicate when a page shows several charts.
- Empty filters fold away only when a form initializes or a chip is removed — in #92 `hideEmptyFilters` ran on every reload, so picking an empty value (e.g. “All”) made the control vanish mid-edit.
- Removing an already-empty filter no longer refetches the chart.
- Colors use the Django admin CSS variables (`--body-bg`, `--border-color`, …) with light fallbacks, so the bar follows the admin dark theme; #92 hardcoded light colors.
- The filters section renders server-side only when the chart has dynamic filters (`ChartSettingsForm.has_chart_filters`) instead of being shown and re-hidden by JS.
- Dropdown closes on outside click and Escape; `aria-expanded`/`aria-haspopup` kept in step.

## Tests

- `npm test`: 21/21 pass — new coverage for fold-away on load, add-back with first real choice + reload, remove + reload, no-reload on removing an empty filter, outside-click/Escape closing.
- `python manage.py test admin_tools_stats`: 158 tests pass, including `AdminChartsFixtureTests` against the regenerated `js_tests/fixtures/chart_form.html`.
- black / flake8 / isort / mypy clean; pre-commit hooks passed on commit.

Verified visually in headless Chrome at 1200px and 400px, including the dropdown-open and chip-added states.

Supersedes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
